### PR TITLE
feat: add inference option for TradeCard builds

### DIFF
--- a/api/build-card.js
+++ b/api/build-card.js
@@ -5,6 +5,7 @@
 // 3) PATCH /wp-json/custom/v1/acf-sync/{id}
 
 const { scrapePage } = require('./scrape');
+const { inferTradecard } = require('./infer');
 
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
 const isHttp = (u) => { try { return ALLOWED_PROTOCOLS.has(new URL(u).protocol); } catch { return false; } };
@@ -191,3 +192,54 @@ async function wpAcfSync(base, id, fields) {
 
 // ---- Map TradeCard JSON → your flattened ACF fields (per your schema) ----
 // Only include keys that have values (your custom endpoint us
+
+exports.crawlSite = crawlSite;
+exports.buildTradecardFromPages = buildTradecardFromPages;
+
+exports.default = async function handler(req, res) {
+  const startUrl = req.query?.url;
+  if (!startUrl) return res.status(400).json({ error: 'Missing ?url=' });
+
+  const maxPages = Math.min(parseInt(req.query?.maxPages || '12', 10) || 12, 50);
+  const maxDepth = Math.min(parseInt(req.query?.maxDepth || '2', 10) || 2, 5);
+  const sameOriginOnly = (req.query?.sameOrigin ?? '1') !== '0';
+
+  try {
+    const pages = await crawlSite(startUrl, { maxPages, maxDepth, sameOriginOnly });
+    const result = buildTradecardFromPages(startUrl, pages);
+
+    if (req.query?.infer === '1' && process.env.OPENAI_API_KEY) {
+      try {
+        const inferred = await inferTradecard(result.tradecard);
+        const applied = [];
+        if (inferred?.business?.description) {
+          result.tradecard.business.description = inferred.business.description;
+          applied.push('business.description');
+        }
+        if (Array.isArray(inferred?.services?.list)) {
+          result.tradecard.services.list = inferred.services.list;
+          applied.push('services.list');
+        }
+        if (Array.isArray(inferred?.service_areas)) {
+          result.tradecard.service_areas = inferred.service_areas;
+          applied.push('service_areas');
+        }
+        if (inferred?.brand?.tone) {
+          result.tradecard.brand.tone = inferred.brand.tone;
+          applied.push('brand.tone');
+        }
+        if (Array.isArray(inferred?.testimonials)) {
+          result.tradecard.testimonials = inferred.testimonials;
+          applied.push('testimonials');
+        }
+        result.needs_inference = result.needs_inference.filter(k => !applied.includes(k));
+      } catch (err) {
+        console.warn('Inference failed:', err.message || err);
+      }
+    }
+
+    return res.status(200).json(result);
+  } catch (err) {
+    return res.status(500).json({ error: err.message || 'Failed to build card' });
+  }
+};

--- a/api/infer.js
+++ b/api/infer.js
@@ -1,0 +1,45 @@
+// api/infer.js
+// Calls OpenAI to infer additional TradeCard fields from scraped data.
+
+const fetch = require('node-fetch');
+
+async function inferTradecard(tradecard) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY required');
+
+  const summary = {
+    name: tradecard?.business?.name,
+    headings: (tradecard?.content?.headings || []).slice(0, 25),
+    contacts: tradecard?.contacts,
+    images: (tradecard?.assets?.images || []).slice(0, 5),
+  };
+
+  const systemPrompt = 'You are a helpful assistant that extracts structured business information.';
+  const userPrompt = `Given the following scraped data, provide a JSON object with optional keys \n` +
+    `business.description (string), services.list (array of strings), service_areas (array of strings),\n` +
+    `brand.tone (string), testimonials (array). Only include keys with non-null values.\n\n` +
+    `${JSON.stringify(summary)}`;
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }
+      ],
+      temperature: 0.2
+    })
+  });
+
+  const json = await res.json().catch(() => ({}));
+  let content = json.choices && json.choices[0] && json.choices[0].message && json.choices[0].message.content;
+  if (!content) return {};
+  try { return JSON.parse(content); } catch { return {}; }
+}
+
+module.exports = { inferTradecard };

--- a/api/openapi.json.js
+++ b/api/openapi.json.js
@@ -71,12 +71,13 @@ const SPEC = {
       get: {
         operationId: "buildTradeCard",
         summary: "Build a TradeCard JSON from a site",
-        description: "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON. Leaves inference fields null.",
+        description: "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON. When infer=1 and OPENAI_API_KEY is set, attempts to infer business.description, services.list, service_areas, brand.tone, and testimonials.",
         parameters: [
           { name: "url", in: "query", required: true, schema: { type: "string", format: "uri" } },
           { name: "maxPages", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 50, default: 12 } },
           { name: "maxDepth", in: "query", required: false, schema: { type: "integer", minimum: 0, maximum: 5, default: 2 } },
           { name: "sameOrigin", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 1 } },
+          { name: "infer", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1 and OPENAI_API_KEY is set, infer missing fields (business.description, services.list, service_areas, brand.tone, testimonials)" },
           { name: "save", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 1 }, description: "If BOSTONOS_API_TOKEN is set, save to BostonOS when save=1" }
         ],
         responses: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,12 +3,13 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "": {
-      "dependencies": {
-        "cheerio": "^1.1.2",
-        "node-fetch": "^3.3.2"
-      }
-    },
+      "": {
+        "dependencies": {
+          "cheerio": "^1.1.2",
+          "node-fetch": "^3.3.2",
+          "openai": "^4.0.0"
+        }
+      },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,1 +1,1 @@
-{"dependencies":{"cheerio":"^1.1.2","node-fetch":"^3.3.2"}}
+{"dependencies":{"cheerio":"^1.1.2","node-fetch":"^3.3.2","openai":"^4.0.0"}}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -46,12 +46,13 @@
       "get": {
         "operationId": "buildTradeCard",
         "summary": "Build a TradeCard JSON from a site",
-        "description": "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON. Leaves inference fields null.",
+        "description": "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON. When infer=1 and OPENAI_API_KEY is set, attempts to infer business.description, services.list, service_areas, brand.tone, and testimonials.",
         "parameters": [
           { "name": "url", "in": "query", "required": true, "schema": { "type": "string", "format": "uri" } },
           { "name": "maxPages", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 50, "default": 12 } },
           { "name": "maxDepth", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 0, "maximum": 5, "default": 2 } },
           { "name": "sameOrigin", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 1 } },
+          { "name": "infer", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1 and OPENAI_API_KEY is set, infer missing fields (business.description, services.list, service_areas, brand.tone, testimonials)" },
           { "name": "save", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 1 }, "description": "If BOSTONOS_API_TOKEN is set, save to BostonOS when save=1" }
         ],
         "responses": {


### PR DESCRIPTION
## Summary
- add `inferTradecard` helper using OpenAI chat completions
- allow `/api/build-card` to merge inferred fields when `infer=1`
- document new `infer` query parameter in OpenAPI specs

## Testing
- `node -c api/infer.js`
- `node -c api/build-card.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a65eb19904832ab9765f3b811f6016