### PR TITLE
Add API health check endpoint

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,15 @@
+// api/index.js
+// Health check and API index listing available endpoints.
+
+module.exports = async function handler(req, res) {
+  res.status(200).json({
+    status: 'ok',
+    endpoints: [
+      '/api/scrape',
+      '/api/crawl',
+      '/api/build',
+      '/api/openapi.json'
+    ]
+  });
+};
+

--- a/api/openapi.json.js
+++ b/api/openapi.json.js
@@ -22,6 +22,17 @@ const SPEC = {
   // If you want to lock this behind an API key later, uncomment security + components.securitySchemes
   // security: [{ ApiKeyAuth: [] }],
   paths: {
+    "/api": {
+      get: {
+        operationId: "healthCheck",
+        summary: "Health check and list available endpoints",
+        responses: {
+          "200": {
+            description: "API status and available endpoints"
+          }
+        }
+      }
+    },
     "/api/scrape": {
       get: {
         operationId: "scrapePage",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -10,6 +10,15 @@
     { "url": "http://localhost:3000", "description": "Local Dev" }
   ],
   "paths": {
+    "/api": {
+      "get": {
+        "operationId": "healthCheck",
+        "summary": "Health check and list available endpoints",
+        "responses": {
+          "200": { "description": "API status and available endpoints" }
+        }
+      }
+    },
     "/api/scrape": {
       "get": {
         "operationId": "scrapePage",


### PR DESCRIPTION
## Summary
- add `/api` health check endpoint that lists available routes
- document new endpoint in OpenAPI spec

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a67509e828832ab6345a4967e12b93