### PR TITLE
Add initial automated tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
   "name": "tradecard-api",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
       "": {
+        "name": "tradecard-api",
+        "version": "1.0.0",
         "dependencies": {
           "cheerio": "^1.1.2",
           "node-fetch": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,1 +1,13 @@
-{"dependencies":{"cheerio":"^1.1.2","node-fetch":"^3.3.2","openai":"^4.0.0"}}
+{
+  "name": "tradecard-api",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "cheerio": "^1.1.2",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.0.0"
+  }
+}

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('assert');
+const { buildTradecardFromPages } = require('../lib/build');
+
+test('buildTradecardFromPages assembles tradecard data', () => {
+  const pages = [
+    {
+      url: 'https://example.com',
+      title: 'Example Co - Home',
+      headings: { h1: ['Welcome'], h2: [], h3: [] },
+      images: [
+        'https://example.com/logo.png',
+        'https://example.com/hero.jpg'
+      ],
+      links: [],
+      social: [{ platform: 'twitter', url: 'https://twitter.com/example' }],
+      contacts: { emails: ['hello@example.com'], phones: ['123'] }
+    }
+  ];
+
+  const result = buildTradecardFromPages('https://example.com', pages);
+
+  assert.strictEqual(result.tradecard.business.name, 'Example Co');
+  assert.deepStrictEqual(result.tradecard.contacts.emails, ['hello@example.com']);
+  assert.deepStrictEqual(result.tradecard.social, [
+    { platform: 'twitter', url: 'https://twitter.com/example' }
+  ]);
+  assert.strictEqual(result.tradecard.assets.logo, 'https://example.com/logo.png');
+  assert.strictEqual(result.tradecard.assets.hero, 'https://example.com/hero.jpg');
+});

--- a/test/fetch_html.test.js
+++ b/test/fetch_html.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('assert');
+const { fetchHtml } = require('../lib/fetch_html');
+
+test('fetchHtml rejects invalid URL', async () => {
+  await assert.rejects(() => fetchHtml('not a url'), /Invalid URL/);
+});
+
+test('fetchHtml rejects non-http protocols', async () => {
+  await assert.rejects(() => fetchHtml('ftp://example.com'), /http/);
+});

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('assert');
+const { parse } = require('../lib/parse');
+
+test('parse extracts data from simple html', async () => {
+  const html = `<!DOCTYPE html>
+  <html><head><title>Test Page</title></head>
+  <body>
+    <h1>Welcome</h1>
+    <h2>About</h2>
+    <img src="/img/logo.png" />
+    <a href="mailto:test@example.com">Email</a>
+    <a href="https://twitter.com/test">Twitter</a>
+  </body></html>`;
+
+  const page = await parse(html, 'https://example.com');
+
+  assert.strictEqual(page.title, 'Test Page');
+  assert.deepStrictEqual(page.headings.h1, ['Welcome']);
+  assert(page.images.includes('https://example.com/img/logo.png'));
+  assert.deepStrictEqual(page.contacts.emails, ['test@example.com']);
+  assert.deepStrictEqual(page.social, [
+    { platform: 'twitter', url: 'https://twitter.com/test' }
+  ]);
+});


### PR DESCRIPTION
## Summary
- configure `npm test` to use Node's built-in test runner
- add tests for HTML parsing, tradecard building, and URL fetching edge cases

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68a675497bfc832a8fa6dd5346e6f636