### PR TITLE
feat: improve inference and wordpress push

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -62,17 +62,19 @@ module.exports = async function handler(req, res) {
         const base = process.env.WP_BASE;
         const token = process.env.WP_BEARER;
         const steps = [];
+        const pushStep = (step, resp) => {
+          steps.push({ step, response: { ok: resp.ok, status: resp.status } });
+          trace.push({ stage: 'push', step, ok: resp.ok, status: resp.status });
+        };
         let postId;
         try {
           const create = await createPost(base, token, { title: result.tradecard.business.name });
-          steps.push({ step: 'create', ...create });
-          trace.push({ stage: 'push', step: 'create', ok: create.ok, status: create.status });
+          pushStep('create', create);
           if (create.ok) postId = create.json?.id;
 
           if (postId && result.tradecard.assets.logo) {
             const up = await uploadFromUrl(base, token, result.tradecard.assets.logo);
-            steps.push({ step: 'upload_logo', ...up });
-            trace.push({ stage: 'push', step: 'upload_logo', ok: up.ok, status: up.status });
+            pushStep('upload_logo', up);
             if (up.ok && (up.json?.url || up.json?.source_url)) {
               result.tradecard.assets.logo = up.json.url || up.json.source_url;
             }
@@ -80,8 +82,7 @@ module.exports = async function handler(req, res) {
 
           if (postId && result.tradecard.assets.hero) {
             const up = await uploadFromUrl(base, token, result.tradecard.assets.hero);
-            steps.push({ step: 'upload_hero', ...up });
-            trace.push({ stage: 'push', step: 'upload_hero', ok: up.ok, status: up.status });
+            pushStep('upload_hero', up);
             if (up.ok && (up.json?.url || up.json?.source_url)) {
               result.tradecard.assets.hero = up.json.url || up.json.source_url;
             }
@@ -90,8 +91,7 @@ module.exports = async function handler(req, res) {
           if (postId) {
             const fields = mapAcf(result.tradecard);
             const acf = await acfSync(base, token, postId, fields);
-            steps.push({ step: 'acf_sync', ...acf });
-            trace.push({ stage: 'push', step: 'acf_sync', ok: acf.ok, status: acf.status });
+            pushStep('acf_sync', acf);
             wordpress = { ok: acf.ok && create.ok, post_id: postId, details: { steps } };
           } else {
             wordpress = { ok: false, post_id: postId, details: { steps } };

--- a/api/openapi.json.js
+++ b/api/openapi.json.js
@@ -11,7 +11,7 @@ const SPEC = {
   },
   servers: [
     {
-      url: "https://tradecard-api-ten.vercel.app"
+      url: "https://tradecard-api.vercel.app"
     }
   ],
   // If you want to lock this behind an API key later, uncomment security + components.securitySchemes
@@ -85,7 +85,8 @@ const SPEC = {
           { name: "sameOrigin", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 1 } },
           { name: "infer", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1 and OPENAI_API_KEY is set, infer missing fields (business.description, services.list, service_areas, brand.tone, testimonials)" },
           { name: "save", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 1 }, description: "If BOSTONOS_API_TOKEN is set, save to BostonOS when save=1" },
-          { name: "push", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1 and WP_BASE/WP_BEARER are set, push TradeCard to WordPress" }
+          { name: "push", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1 and WP_BASE/WP_BEARER are set, push TradeCard to WordPress" },
+          { name: "debug", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1, include debug.trace with stage timings" }
         ],
         responses: {
           "200": {
@@ -246,6 +247,16 @@ const SPEC = {
           },
           needs_inference: { type: "array", items: { type: "string" } },
           persisted: {
+            type: "object",
+            nullable: true,
+            additionalProperties: true
+          },
+          wordpress: {
+            type: "object",
+            nullable: true,
+            additionalProperties: true
+          },
+          debug: {
             type: "object",
             nullable: true,
             additionalProperties: true

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -26,9 +26,14 @@ async function inferTradecard(tradecard = {}) {
 
   const summary = {
     name: tradecard?.business?.name,
-    headings: (tradecard?.content?.headings || []).slice(0, 30),
-    contacts: tradecard?.contacts,
-    images: (tradecard?.assets?.images || []).slice(0, 5)
+    headings: (tradecard?.content?.headings || [])
+      .map(h => h.text)
+      .slice(0, 25),
+    contacts: {
+      emails: tradecard?.contacts?.emails || [],
+      phones: tradecard?.contacts?.phones || []
+    },
+    images: (tradecard?.assets?.images || []).slice(0, 3)
   };
 
   const controller = new AbortController();
@@ -68,9 +73,26 @@ async function inferTradecard(tradecard = {}) {
   if (!content) {
     return { _meta: { error: 'no_content', detail: data } };
   }
+  const strip = content
+    .replace(/^```[a-z]*\n?/i, '')
+    .replace(/```$/i, '')
+    .trim();
   let parsed;
-  try { parsed = JSON.parse(content); }
-  catch (err) { return { _meta: { error: 'invalid_json', detail: content } }; }
+  try {
+    parsed = JSON.parse(strip);
+  } catch {
+    const start = strip.indexOf('{');
+    const end = strip.lastIndexOf('}');
+    if (start !== -1 && end !== -1 && end > start) {
+      try {
+        parsed = JSON.parse(strip.slice(start, end + 1));
+      } catch (err) {
+        return { _meta: { error: 'invalid_json', detail: err.message } };
+      }
+    } else {
+      return { _meta: { error: 'invalid_json', detail: 'no_json_object' } };
+    }
+  }
 
   return pickAllowed(parsed);
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -6,7 +6,7 @@
     "description": "Deterministic site scraping, crawling, and TradeCard JSON builder. Returns structured data suitable for downstream inference."
   },
   "servers": [
-    { "url": "https://tradecard-api-ten.vercel.app" }
+    { "url": "https://tradecard-api.vercel.app" }
   ],
   "paths": {
     "/api": {
@@ -62,7 +62,8 @@
           { "name": "sameOrigin", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 1 } },
           { "name": "infer", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1 and OPENAI_API_KEY is set, infer missing fields (business.description, services.list, service_areas, brand.tone, testimonials)" },
           { "name": "save", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 1 }, "description": "If BOSTONOS_API_TOKEN is set, save to BostonOS when save=1" },
-          { "name": "push", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1 and WP_BASE/WP_BEARER are set, push TradeCard to WordPress" }
+          { "name": "push", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1 and WP_BASE/WP_BEARER are set, push TradeCard to WordPress" },
+          { "name": "debug", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1, include debug.trace with stage timings" }
         ],
         "responses": {
           "200": { "description": "TradeCard result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/BuildCardResponse" } } } },
@@ -200,7 +201,9 @@
             }
           },
           "needs_inference": { "type": "array", "items": { "type": "string" } },
-          "persisted": { "type": "object", "nullable": true, "additionalProperties": true }
+          "persisted": { "type": "object", "nullable": true, "additionalProperties": true },
+          "wordpress": { "type": "object", "nullable": true, "additionalProperties": true },
+          "debug": { "type": "object", "nullable": true, "additionalProperties": true }
         },
         "required": ["site","tradecard","provenance","needs_inference"]
       }

--- a/test/build_route.test.js
+++ b/test/build_route.test.js
@@ -38,4 +38,8 @@ test('build route performs crawl, inference, push', async () => {
   assert.ok(!res.body.needs_inference.includes('business.description'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'crawl'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'infer_merge'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'push' && t.step === 'acf_sync'));
+  const steps = res.body.wordpress.details.steps;
+  assert.deepEqual(steps.map(s => s.step), ['create','upload_logo','upload_hero','acf_sync']);
+  assert.ok(steps[0].response.ok);
 });

--- a/test/infer.test.js
+++ b/test/infer.test.js
@@ -4,11 +4,11 @@ const { inferTradecard } = require('../lib/infer');
 const mockFetch = require('./helpers/mockFetch');
 const resetEnv = require('./helpers/resetEnv');
 
-test('inferTradecard returns whitelisted fields', async () => {
+test('inferTradecard tolerates fenced JSON and filters fields', async () => {
   resetEnv({ OPENAI_API_KEY: 'k' });
   const restore = mockFetch({
     'https://api.openai.com/v1/chat/completions': {
-      json: { choices: [{ message: { content: '{"business":{"description":"desc"},"services":{"list":["a"]},"extra":1}' } }] }
+      json: { choices: [{ message: { content: '```json\n{"business":{"description":"desc"},"services":{"list":["a"]},"extra":1}\n```' } }] }
     }
   });
   const out = await inferTradecard({ business: { name: 'x' } });
@@ -16,13 +16,15 @@ test('inferTradecard returns whitelisted fields', async () => {
   assert.deepEqual(out, { business: { description: 'desc' }, services: { list: ['a'] } });
 });
 
-test('inferTradecard reports errors in _meta', async () => {
+test('inferTradecard reports invalid JSON in _meta', async () => {
   resetEnv({ OPENAI_API_KEY: 'k' });
   const restore = mockFetch({
-    'https://api.openai.com/v1/chat/completions': { status: 500, json: { error: 'bad' } }
+    'https://api.openai.com/v1/chat/completions': {
+      json: { choices: [{ message: { content: 'not json' } }] }
+    }
   });
   const out = await inferTradecard({});
   restore();
   assert.ok(out._meta);
-  assert.equal(out._meta.status, 500);
+  assert.equal(out._meta.error, 'invalid_json');
 });


### PR DESCRIPTION
## Summary
- harden OpenAI inference parsing and send compact inputs
- trace and structure WordPress push steps; add debug query docs
- document debug & wordpress in OpenAPI and switch to production server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c185e92c832a98dc2076d3a38ec6