### PR TITLE
feat: enhance inference robustness and traceability

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -25,7 +25,7 @@ module.exports = async function handler(req, res) {
     const result = buildTradecardFromPages(startUrl, pages);
 
     trace.push({ stage: 'infer', enabled: doInfer, key_present: !!process.env.OPENAI_API_KEY });
-    if (doInfer && process.env.OPENAI_API_KEY) {
+    if (doInfer) {
       const inferred = await inferTradecard(result.tradecard);
       trace.push({ stage: 'infer_response', meta: inferred._meta });
       const applied = [];

--- a/lib/infer.js
+++ b/lib/infer.js
@@ -20,9 +20,29 @@ function pickAllowed(src = {}) {
   return out;
 }
 
+function tryParseAssistant(content = '') {
+  const stripped = content
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```$/i, '')
+    .trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    const match = stripped.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        return JSON.parse(match[0]);
+      } catch {
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+}
+
 async function inferTradecard(tradecard = {}) {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) return { _meta: { error: 'missing_key' } };
+  if (!apiKey) return { _meta: { skipped: 'no_api_key' } };
 
   const summary = {
     name: tradecard?.business?.name,
@@ -73,28 +93,9 @@ async function inferTradecard(tradecard = {}) {
   if (!content) {
     return { _meta: { error: 'no_content', detail: data } };
   }
-  const strip = content
-    .replace(/^```[a-z]*\n?/i, '')
-    .replace(/```$/i, '')
-    .trim();
-  let parsed;
-  try {
-    parsed = JSON.parse(strip);
-  } catch {
-    const start = strip.indexOf('{');
-    const end = strip.lastIndexOf('}');
-    if (start !== -1 && end !== -1 && end > start) {
-      try {
-        parsed = JSON.parse(strip.slice(start, end + 1));
-      } catch (err) {
-        return { _meta: { error: 'invalid_json', detail: err.message } };
-      }
-    } else {
-      return { _meta: { error: 'invalid_json', detail: 'no_json_object' } };
-    }
-  }
-
-  return pickAllowed(parsed);
+  const parsed = tryParseAssistant(content);
+  if (!parsed) return { _meta: { error: 'invalid_json' } };
+  return { ...pickAllowed(parsed), _meta: { ok: true } };
 }
 
-module.exports = { inferTradecard };
+module.exports = { inferTradecard, tryParseAssistant };

--- a/test/build_route.test.js
+++ b/test/build_route.test.js
@@ -37,6 +37,7 @@ test('build route performs crawl, inference, push', async () => {
   assert.ok(res.body.wordpress.ok);
   assert.ok(!res.body.needs_inference.includes('business.description'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'crawl'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'infer_response'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'infer_merge'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'push' && t.step === 'acf_sync'));
   const steps = res.body.wordpress.details.steps;

--- a/test/infer.test.js
+++ b/test/infer.test.js
@@ -13,7 +13,9 @@ test('inferTradecard tolerates fenced JSON and filters fields', async () => {
   });
   const out = await inferTradecard({ business: { name: 'x' } });
   restore();
-  assert.deepEqual(out, { business: { description: 'desc' }, services: { list: ['a'] } });
+  const { _meta, ...data } = out;
+  assert.deepEqual(data, { business: { description: 'desc' }, services: { list: ['a'] } });
+  assert.deepEqual(_meta, { ok: true });
 });
 
 test('inferTradecard reports invalid JSON in _meta', async () => {
@@ -25,6 +27,11 @@ test('inferTradecard reports invalid JSON in _meta', async () => {
   });
   const out = await inferTradecard({});
   restore();
-  assert.ok(out._meta);
   assert.equal(out._meta.error, 'invalid_json');
+});
+
+test('inferTradecard skips without API key', async () => {
+  resetEnv({});
+  const out = await inferTradecard({});
+  assert.deepEqual(out, { _meta: { skipped: 'no_api_key' } });
 });


### PR DESCRIPTION
## Summary
- add helper to parse assistant responses without node-fetch
- return detailed `_meta` from `inferTradecard` and handle missing API key
- trace inference response and merge steps in build route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ab7f5300832a8e5c858762b4ffef