### PR TITLE
feat: expand ACF mapping and audit

### DIFF
--- a/lib/mapAcf.js
+++ b/lib/mapAcf.js
@@ -5,65 +5,99 @@ function nonEmpty(val) {
   return true;
 }
 
-function mapAcf(tc = {}) {
+function addField(out, key, value) {
+  if (value === undefined || value === null) return;
+  if (Array.isArray(value)) {
+    const arr = value
+      .map(v => (typeof v === 'string' ? v.trim() : v))
+      .filter(v => nonEmpty(v));
+    if (!arr.length) return;
+    value = arr.join(', ');
+  } else if (typeof value === 'string') {
+    value = value.trim();
+    if (!value) return;
+  }
+  out[key] = value;
+}
+
+function normalizeEmail(email) {
+  if (typeof email !== 'string') return '';
+  return email.trim().toLowerCase();
+}
+
+function normalizePhone(phone) {
+  if (typeof phone !== 'string') return '';
+  return phone.replace(/\D/g, '');
+}
+
+function mapTradecardToAcf(tc = {}) {
   const fields = {};
 
-  const identity = {
-    identity_business_name: tc.business?.name,
-    identity_website_url: tc.contacts?.website,
-    identity_email: tc.contacts?.emails?.[0],
-    identity_phone: tc.contacts?.phones?.[0],
-    identity_logo_url: tc.assets?.logo
-  };
-  for (const [k, v] of Object.entries(identity)) {
-    if (nonEmpty(v)) fields[k] = v;
-  }
+  addField(fields, 'identity_business_name', tc.business?.name);
+  addField(fields, 'identity_website_url', tc.contacts?.website);
 
-  const socials = tc.social || [];
-  const platforms = ['facebook','instagram','linkedin','twitter','youtube','tiktok'];
+  const email = normalizeEmail(tc.contacts?.emails?.[0]);
+  if (email) fields.identity_email = email;
+
+  const phone = normalizePhone(tc.contacts?.phones?.[0]);
+  if (phone) fields.identity_phone = phone;
+
+  addField(fields, 'identity_logo_url', tc.assets?.logo);
+
+  const socials = Array.isArray(tc.social) ? tc.social : [];
+  const platforms = ['facebook', 'instagram', 'linkedin', 'twitter', 'youtube', 'tiktok'];
   for (const plat of platforms) {
     const item = socials.find(s => s.platform === plat);
-    if (item && nonEmpty(item.url)) fields[`social_links_${plat}`] = item.url;
+    addField(fields, `social_links_${plat}`, item?.url);
+  }
+
+  addField(fields, 'business_description', tc.business?.description);
+
+  if (Array.isArray(tc.service_areas)) {
+    addField(fields, 'service_areas_csv', tc.service_areas);
   }
 
   const services = Array.isArray(tc.services?.list) ? tc.services.list : [];
   for (let i = 0; i < Math.min(3, services.length); i++) {
     const svc = services[i];
-    const prefix = `services_${i + 1}_`;
+    const prefix = `service_${i + 1}_`;
     if (typeof svc === 'string') {
-      if (nonEmpty(svc)) fields[`${prefix}title`] = svc;
+      addField(fields, `${prefix}title`, svc);
       continue;
     }
     if (!svc || typeof svc !== 'object') continue;
-    const { title, name, subtitle, description, image_url, price, price_note, cta_label, cta_link, video_url } = svc;
-    const deliver = svc.delivery_modes;
-    const inclusions = svc.inclusions || [];
-    const tags = svc.tags;
-
-    if (nonEmpty(title || name)) fields[`${prefix}title`] = title || name;
-    if (nonEmpty(subtitle)) fields[`${prefix}subtitle`] = subtitle;
-    if (nonEmpty(description)) fields[`${prefix}description`] = description;
-    if (nonEmpty(image_url)) fields[`${prefix}image_url`] = image_url;
-    if (nonEmpty(price)) fields[`${prefix}price`] = price;
-    if (nonEmpty(price_note)) fields[`${prefix}price_note`] = price_note;
-    if (nonEmpty(cta_label)) fields[`${prefix}cta_label`] = cta_label;
-    if (nonEmpty(cta_link)) fields[`${prefix}cta_link`] = cta_link;
-    if (nonEmpty(deliver)) {
-      const val = Array.isArray(deliver) ? deliver.join(', ') : deliver;
-      if (nonEmpty(val)) fields[`${prefix}delivery_modes`] = val;
-    }
+    const {
+      title,
+      name,
+      subtitle,
+      description,
+      image_url,
+      price,
+      price_note,
+      cta_label,
+      cta_link,
+      delivery_modes,
+      video_url,
+      tags
+    } = svc;
+    addField(fields, `${prefix}title`, title || name);
+    addField(fields, `${prefix}subtitle`, subtitle);
+    addField(fields, `${prefix}description`, description);
+    addField(fields, `${prefix}image_url`, image_url);
+    addField(fields, `${prefix}price`, price);
+    addField(fields, `${prefix}price_note`, price_note);
+    addField(fields, `${prefix}cta_label`, cta_label);
+    addField(fields, `${prefix}cta_link`, cta_link);
+    addField(fields, `${prefix}delivery_modes`, delivery_modes);
     for (let j = 1; j <= 3; j++) {
-      const inc = svc[`inclusion_${j}`] || inclusions[j - 1];
-      if (nonEmpty(inc)) fields[`${prefix}inclusion_${j}`] = inc;
+      const inc = svc[`inclusion_${j}`] || (Array.isArray(svc.inclusions) ? svc.inclusions[j - 1] : undefined);
+      addField(fields, `${prefix}inclusion_${j}`, inc);
     }
-    if (nonEmpty(video_url)) fields[`${prefix}video_url`] = video_url;
-    if (nonEmpty(tags)) {
-      const val = Array.isArray(tags) ? tags.join(', ') : tags;
-      if (nonEmpty(val)) fields[`${prefix}tags`] = val;
-    }
+    addField(fields, `${prefix}video_url`, video_url);
+    addField(fields, `${prefix}tags`, tags);
   }
 
   return fields;
 }
 
-module.exports = { mapAcf };
+module.exports = { mapTradecardToAcf };


### PR DESCRIPTION
## Summary
- map TradeCard data to ACF keys with trimming, email/phone normalization and service metadata
- record ACF keys in WordPress push trace and include sent key audit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bb36c300832a99826bf85a5a717a