### PR TITLE
feat: add robust ACF sync mapping

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -105,10 +105,10 @@ module.exports = async function handler(req, res) {
 
           if (postId) {
             const acfPayload = mapTradecardToAcf(result.tradecard);
-            const details = { steps, acf_keys: Object.keys(acfPayload) };
-            const acf = await acfSync(base, token, postId, acfPayload);
-            steps.push({ step: 'acf_sync', response: { ok: acf.ok, status: acf.status }, sent_keys: details.acf_keys });
+            const acf = await acfSync(base, token, postId, acfPayload.fields);
+            steps.push({ step: 'acf_sync', response: { ok: acf.ok, status: acf.status }, sent_keys: acf.accepted_keys, tried: acf.tried });
             trace.push({ stage: 'push', step: 'acf_sync', ok: acf.ok, status: acf.status });
+            const details = { steps, acf_keys: { sent_keys: acf.accepted_keys, tried: acf.tried } };
             wordpress = { ok: acf.ok && create.ok, post_id: postId, details };
           } else {
             wordpress = { ok: false, post_id: postId, details: { steps } };

--- a/lib/mapAcf.js
+++ b/lib/mapAcf.js
@@ -51,7 +51,44 @@ function mapTradecardToAcf(tc = {}) {
     addField(fields, `social_links_${plat}`, item?.url);
   }
 
-  return fields;
+  addField(fields, 'business_description', tc.business?.description);
+
+  if (Array.isArray(tc.service_areas)) {
+    const areas = [...new Set(tc.service_areas.map(a => (typeof a === 'string' ? a.trim() : a)).filter(nonEmpty))];
+    if (areas.length) fields.service_areas_csv = areas.join(', ');
+  }
+
+  let services = [];
+  if (Array.isArray(tc.services)) services = tc.services;
+  else if (Array.isArray(tc.services?.list)) services = tc.services.list;
+  services = services.filter(s => s && typeof s === 'object');
+
+  for (let i = 0; i < Math.min(3, services.length); i++) {
+    const svc = services[i] || {};
+    const idx = i + 1;
+    addField(fields, `service_${idx}_title`, svc.title);
+    addField(fields, `service_${idx}_subtitle`, svc.subtitle);
+    addField(fields, `service_${idx}_description`, svc.description);
+    addField(fields, `service_${idx}_image_url`, svc.image_url || svc.image);
+    addField(fields, `service_${idx}_price`, svc.price);
+    addField(fields, `service_${idx}_price_note`, svc.price_note);
+    addField(fields, `service_${idx}_cta_label`, svc.cta_label);
+    addField(fields, `service_${idx}_cta_link`, svc.cta_link);
+    addField(fields, `service_${idx}_delivery_modes`, svc.delivery_modes);
+    if (Array.isArray(svc.inclusions)) {
+      addField(fields, `service_${idx}_inclusion_1`, svc.inclusions[0]);
+      addField(fields, `service_${idx}_inclusion_2`, svc.inclusions[1]);
+      addField(fields, `service_${idx}_inclusion_3`, svc.inclusions[2]);
+    } else {
+      addField(fields, `service_${idx}_inclusion_1`, svc.inclusion_1);
+      addField(fields, `service_${idx}_inclusion_2`, svc.inclusion_2);
+      addField(fields, `service_${idx}_inclusion_3`, svc.inclusion_3);
+    }
+    addField(fields, `service_${idx}_video_url`, svc.video_url);
+    addField(fields, `service_${idx}_tags`, svc.tags);
+  }
+
+  return { fields, keys: Object.keys(fields) };
 }
 
 module.exports = { mapTradecardToAcf };

--- a/lib/wp.js
+++ b/lib/wp.js
@@ -34,11 +34,26 @@ async function uploadFromUrl(base, token, url) {
 }
 
 async function acfSync(base, token, id, fields) {
-  return fetchJson(`${base}/wp-json/custom/v1/acf-sync/${id}`, {
-    method: 'PATCH',
-    headers: authHeaders(token),
-    body: JSON.stringify(fields)
+  const url = `${base}/wp-json/custom/v1/acf-sync/${id}`;
+  const headers = authHeaders(token);
+  const tried = ['wrapped'];
+
+  let resp = await fetchJson(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ fields })
   });
+
+  if (resp.status === 400 || resp.status === 422) {
+    tried.push('raw');
+    resp = await fetchJson(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(fields)
+    });
+  }
+
+  return { ...resp, tried, accepted_keys: Object.keys(fields) };
 }
 
 module.exports = { createPost, uploadFromUrl, acfSync };


### PR DESCRIPTION
## Summary
- expand Tradecard→ACF mapper to include description, service areas, and up to three service blocks, returning sent keys
- harden ACF sync to retry with raw payload and report attempted keys
- expose sent ACF keys and retry mode in build push details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e27b0904832a8b6c1812f27f4e25