### PR TITLE
feat: add intent-driven ACF sync

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+let cachedRules;
+
+function expandServiceKeys(rules = {}) {
+  const out = {};
+  for (const [key, val] of Object.entries(rules)) {
+    if (key.includes('{i}')) {
+      for (let i = 1; i <= 3; i++) {
+        out[key.replace('{i}', i)] = val;
+      }
+    } else {
+      out[key] = val;
+    }
+  }
+  return out;
+}
+
+function loadIntent(path = 'config/field_intent_map.yaml') {
+  const text = fs.readFileSync(path, 'utf8');
+  const cleaned = text
+    .split(/\r?\n/)
+    .filter((line) => !line.trim().startsWith('<'))
+    .join('\n');
+  let doc = {};
+  try {
+    doc = yaml.load(cleaned) || {};
+  } catch {
+    doc = {};
+  }
+  const filtered = Object.fromEntries(
+    Object.entries(doc).filter(([k]) => !k.startsWith('_'))
+  );
+  cachedRules = expandServiceKeys(filtered);
+  return cachedRules;
+}
+
+function applyIntent(tradecard = {}) {
+  const rules = cachedRules || loadIntent();
+  const fields = {};
+  const sent_keys = [];
+  const dropped_empty = [];
+  const dropped_unknown = [];
+
+  for (const [key, rawVal] of Object.entries(tradecard || {})) {
+    if (!rules[key]) {
+      dropped_unknown.push(key);
+      continue;
+    }
+    let val = rawVal;
+    if (val === undefined || val === null) {
+      dropped_empty.push(key);
+      continue;
+    }
+
+    let transforms = rules[key]?.transform || rules[key]?.transforms;
+    if (!Array.isArray(transforms)) transforms = transforms ? [transforms] : [];
+
+    if (Array.isArray(val)) {
+      if (transforms.includes('csv') || transforms.includes('csv(array)')) {
+        val = val
+          .flatMap((v) => {
+            if (v === undefined || v === null) return [];
+            if (Array.isArray(v)) return v;
+            return [v];
+          })
+          .map((v) => (typeof v === 'string' ? v : String(v)))
+          .map((v) => v.trim())
+          .filter(Boolean)
+          .join(',');
+      } else {
+        val = val[0];
+      }
+    }
+
+    if (typeof val === 'string') {
+      if (transforms.includes('trim')) val = val.trim();
+      if (transforms.includes('lower')) val = val.toLowerCase();
+      if (transforms.some((t) => t.startsWith('digits'))) {
+        val = val.replace(/[^+\d]/g, '');
+      }
+    } else if (typeof val === 'number' || typeof val === 'boolean') {
+      val = String(val);
+    } else if (val && typeof val === 'object') {
+      val = '';
+    }
+
+    if (typeof val === 'string' && transforms.length === 0) {
+      val = val.trim();
+    }
+
+    if (val === '' || val === undefined) {
+      dropped_empty.push(key);
+      continue;
+    }
+
+    fields[key] = val;
+    sent_keys.push(key);
+  }
+
+  return { fields, sent_keys, dropped_empty, dropped_unknown };
+}
+
+module.exports = { loadIntent, applyIntent };

--- a/lib/wp.js
+++ b/lib/wp.js
@@ -35,16 +35,11 @@ async function uploadFromUrl(base, token, url) {
 
 async function acfSync(base, token, id, fields) {
   const url = `${base.replace(/\/$/, '')}/wp-json/custom/v1/acf-sync/${id}`;
-  const flat = {};
-  for (const [k, v] of Object.entries(fields || {})) {
-    flat[k] = v == null ? '' : String(v);
-  }
-  const resp = await fetchJson(url, {
+  return fetchJson(url, {
     method: 'PATCH',
     headers: authHeaders(token),
-    body: JSON.stringify(flat)
+    body: JSON.stringify(fields || {})
   });
-  return { ...resp, sent_keys: Object.keys(flat) };
 }
 
 module.exports = { createPost, uploadFromUrl, acfSync };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,15 @@
       "name": "tradecard-api",
       "version": "1.0.0",
       "dependencies": {
-        "cheerio": "^1.1.2"
+        "cheerio": "^1.1.2",
+        "js-yaml": "^4.1.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -208,6 +215,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/nth-check": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "cheerio": "^1.1.2"
+    "cheerio": "^1.1.2",
+    "js-yaml": "^4.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add intent mapping utilities to load YAML rules and prepare ACF field payloads
- switch acfSync to custom WP route and integrate intent-driven sync in build pipeline
- add js-yaml dependency for YAML parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a839330068832a8df71af398933087