### PR TITLE
feat: add YAML config loader and enhance fetch mocks

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+let YAML;
+try { YAML = require('yaml'); }
+catch { YAML = require('js-yaml'); }
+
+function readYaml(rel) {
+  const candidates = [
+    path.join(process.cwd(), rel),
+    path.join(__dirname, '..', rel),
+    path.resolve(rel),
+  ];
+  for (const p of candidates) {
+    try {
+      const src = fs.readFileSync(p, 'utf8');
+      return YAML.parse(src);
+    } catch {}
+  }
+  throw new Error(`YAML not found: ${rel}`);
+}
+
+module.exports = { readYaml };

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const yaml = require('js-yaml');
+const { readYaml } = require('./config');
 
 let cachedRules;
 
@@ -18,14 +17,9 @@ function expandServiceKeys(rules = {}) {
 }
 
 function loadIntent(path = 'config/field_intent_map.yaml') {
-  const text = fs.readFileSync(path, 'utf8');
-  const cleaned = text
-    .split(/\r?\n/)
-    .filter((line) => !line.trim().startsWith('<'))
-    .join('\n');
   let doc = {};
   try {
-    doc = yaml.load(cleaned) || {};
+    doc = readYaml(path) || {};
   } catch {
     doc = {};
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "cheerio": "^1.1.2",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "yaml": "^2.4.5"
   }
 }

--- a/test/helpers/mockFetch.js
+++ b/test/helpers/mockFetch.js
@@ -2,18 +2,25 @@ const { ReadableStream } = require('node:stream/web');
 
 module.exports = function mockFetch(routes = {}) {
   const orig = global.fetch;
+  const calls = [];
   global.fetch = async (url, opts = {}) => {
     const key = typeof url === 'string' ? url : url.url;
+    calls.push({ url: key, opts });
     if (!(key in routes)) throw new Error('No mock for ' + key);
-    const cfg = routes[key];
+    let cfg = routes[key];
+    if (Array.isArray(cfg)) cfg = cfg.shift();
+    if (typeof cfg === 'function') cfg = await cfg(url, opts);
+    if (!cfg) throw new Error('No mock for ' + key);
     const status = cfg.status ?? 200;
     const ok = cfg.ok ?? (status >= 200 && status < 300);
     const body = cfg.body !== undefined
       ? (typeof cfg.body === 'string' ? cfg.body : JSON.stringify(cfg.body))
       : JSON.stringify(cfg.json ?? {});
+    const headers = cfg.headers || {};
     return {
       ok,
       status,
+      headers: { get: (h) => headers[h.toLowerCase()] },
       json: async () => cfg.json !== undefined ? cfg.json : JSON.parse(body),
       text: async () => body,
       body: new ReadableStream({
@@ -24,5 +31,7 @@ module.exports = function mockFetch(routes = {}) {
       })
     };
   };
-  return () => { global.fetch = orig; };
+  const restore = () => { global.fetch = orig; };
+  restore.calls = calls;
+  return restore;
 };


### PR DESCRIPTION
## Summary
- add `yaml` dep and helper to load YAML with robust path resolution
- switch intent loader to use new helper
- expand test mockFetch to allow dynamic responses and capture calls

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a840d98658832ab77e5d819eaecacb