### PR TITLE
feat: support rule-based intent config

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,44 +1,78 @@
+const fs = require('fs');
+const path = require('path');
 const { readYaml } = require('./config');
 
-let cachedRules;
+let cached;
 
-function expandServiceKeys(rules = {}) {
-  const out = {};
-  for (const [key, val] of Object.entries(rules)) {
+function expandServiceKeys(keys = [], indices = [1, 2, 3]) {
+  const out = [];
+  for (const key of keys) {
     if (key.includes('{i}')) {
-      for (let i = 1; i <= 3; i++) {
-        out[key.replace('{i}', i)] = val;
+      for (const i of indices) {
+        out.push(key.replace('{i}', i));
       }
     } else {
-      out[key] = val;
+      out.push(key);
     }
   }
   return out;
 }
 
-function loadIntent(path = 'config/field_intent_map.yaml') {
+function loadIntent(rel = 'config/field_intent_map.yaml') {
+  if (cached) return cached;
+
   let doc = {};
+  let raw = '';
   try {
-    doc = readYaml(path) || {};
+    doc = readYaml(rel) || {};
   } catch {
-    doc = {};
+    // fall back to raw text scanning
+    const candidates = [
+      path.join(process.cwd(), rel),
+      path.join(__dirname, '..', rel),
+      path.resolve(rel),
+    ];
+    for (const p of candidates) {
+      try {
+        raw = fs.readFileSync(p, 'utf8');
+        break;
+      } catch {}
+    }
   }
-  const filtered = Object.fromEntries(
-    Object.entries(doc).filter(([k]) => !k.startsWith('_'))
-  );
-  cachedRules = expandServiceKeys(filtered);
-  return cachedRules;
+
+  let allowKeys = [];
+  if (doc.allow) {
+    allowKeys = Array.isArray(doc.allow) ? doc.allow : [].concat(doc.allow);
+  } else if (Object.keys(doc).length) {
+    allowKeys = Object.keys(doc).filter(
+      (k) => !k.startsWith('_') && k !== 'service_index' && k !== 'allow'
+    );
+  } else if (raw) {
+    const re = /^([A-Za-z0-9_{}]+):/gm;
+    let m;
+    while ((m = re.exec(raw))) {
+      const k = m[1];
+      if (k.startsWith('_') || k === 'service_index' || k === 'allow') continue;
+      allowKeys.push(k);
+    }
+  }
+
+  const indices = doc.service_index || [1, 2, 3];
+  const allow = new Set(expandServiceKeys(allowKeys, indices));
+
+  cached = { allow, doc };
+  return cached;
 }
 
 function applyIntent(tradecard = {}) {
-  const rules = cachedRules || loadIntent();
+  const { allow, doc } = cached || loadIntent();
   const fields = {};
   const sent_keys = [];
   const dropped_empty = [];
   const dropped_unknown = [];
 
   for (const [key, rawVal] of Object.entries(tradecard || {})) {
-    if (!rules[key]) {
+    if (!allow.has(key)) {
       dropped_unknown.push(key);
       continue;
     }
@@ -48,7 +82,7 @@ function applyIntent(tradecard = {}) {
       continue;
     }
 
-    let transforms = rules[key]?.transform || rules[key]?.transforms;
+    let transforms = doc[key]?.transform || doc[key]?.transforms;
     if (!Array.isArray(transforms)) transforms = transforms ? [transforms] : [];
 
     if (Array.isArray(val)) {


### PR DESCRIPTION
## Summary
- add rule-per-field intent loader returning allow set and config
- use new loader in applyIntent while preserving transforms

## Testing
- `node -e "console.log(require('./lib/intent').loadIntent('config/field_intent_map.yaml').allow.size > 0)"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84549d1c0832aa4bc2efb6cf281a8