### PR TITLE
fix: support rule-based intent map

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -40,6 +40,18 @@ function loadIntent(rel = 'config/field_intent_map.yaml') {
     }
   }
 
+  const indices = doc.service_index || [1, 2, 3];
+
+  // expand service_{i}_* templates inside doc itself
+  for (const key of Object.keys(doc)) {
+    if (!key.includes('{i}')) continue;
+    for (const i of indices) {
+      const expanded = key.replace('{i}', i);
+      if (doc[expanded] === undefined) doc[expanded] = doc[key];
+    }
+    delete doc[key];
+  }
+
   let allowKeys = [];
   if (doc.allow) {
     allowKeys = Array.isArray(doc.allow) ? doc.allow : [].concat(doc.allow);
@@ -57,7 +69,6 @@ function loadIntent(rel = 'config/field_intent_map.yaml') {
     }
   }
 
-  const indices = doc.service_index || [1, 2, 3];
   const allow = new Set(expandServiceKeys(allowKeys, indices));
 
   cached = { allow, doc };

--- a/test/build_route.test.js
+++ b/test/build_route.test.js
@@ -53,4 +53,14 @@ test('build route performs crawl, inference, push', async () => {
   const steps = res.body.wordpress.details.steps;
   assert.deepEqual(steps.map(s => s.step), ['create','upload_logo','upload_hero','upload_image','upload_image','acf_sync']);
   assert.ok(steps[0].response.ok);
+
+  const acfKeys = res.body.wordpress.details.acf_keys || [];
+  const { allow } = require('../lib/intent').loadIntent('config/field_intent_map.yaml');
+  assert.ok(acfKeys.length > 0);
+  if (allow.has('identity_business_name')) {
+    assert.ok(acfKeys.includes('identity_business_name'));
+  }
+  if (allow.has('identity_website_url')) {
+    assert.ok(acfKeys.includes('identity_website_url'));
+  }
 });


### PR DESCRIPTION
## Summary
- expand loadIntent to handle rule-per-field YAML and service templates
- assert specific ACF keys instead of brittle thresholds in build route test

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a84bb71614832a9b3cf64e5807a3f1