### PR TITLE
feat: add intent rule resolver with optional inference

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -122,8 +122,13 @@ module.exports = async function handler(req, res) {
           }
 
           if (postId) {
-            const intent = applyIntent(result.tradecard);
+            const intent = await applyIntent(result.tradecard, { infer: req.query.infer === '1' });
             const acf = await acfSync(base, token, postId, intent.fields);
+            const auditSummary = intent.audit.reduce((acc, a) => {
+              acc[a.status] = (acc[a.status] || 0) + 1;
+              return acc;
+            }, {});
+            trace.push({ stage: 'intent', counts: auditSummary });
             steps.push({
               step: 'acf_sync',
               sent_keys: intent.sent_keys,

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { readYaml } = require('./config');
+const { inferTradecard } = require('./infer');
 
 let cached;
 
@@ -75,70 +76,133 @@ function loadIntent(rel = 'config/field_intent_map.yaml') {
   return cached;
 }
 
-function applyIntent(tradecard = {}) {
+function resolvePath(obj = {}, dot = '') {
+  if (!dot) return undefined;
+  const parts = dot.split('.');
+  let cur = obj;
+  for (const p of parts) {
+    if (cur === undefined || cur === null) return undefined;
+    const m = p.match(/(.+)\[(\d+)\]$/);
+    if (m) {
+      cur = cur[m[1]];
+      if (!Array.isArray(cur)) return undefined;
+      cur = cur[parseInt(m[2], 10)];
+    } else {
+      cur = cur[p];
+    }
+  }
+  return cur;
+}
+
+function applyTransforms(val, transforms = []) {
+  if (Array.isArray(val)) {
+    if (transforms.includes('csv') || transforms.includes('csv(array)')) {
+      val = val
+        .flatMap((v) => {
+          if (v === undefined || v === null) return [];
+          if (Array.isArray(v)) return v;
+          return [v];
+        })
+        .map((v) => (typeof v === 'string' ? v : String(v)))
+        .map((v) => v.trim())
+        .filter(Boolean)
+        .join(',');
+    } else {
+      val = val[0];
+    }
+  }
+
+  if (typeof val === 'string') {
+    if (transforms.includes('trim')) val = val.trim();
+    if (transforms.includes('lower')) val = val.toLowerCase();
+    if (transforms.some((t) => t.startsWith('digits'))) {
+      val = val.replace(/[^+\d]/g, '');
+    }
+  } else if (typeof val === 'number' || typeof val === 'boolean') {
+    val = String(val);
+  } else if (val && typeof val === 'object') {
+    val = '';
+  }
+
+  if (typeof val === 'string' && transforms.length === 0) {
+    val = val.trim();
+  }
+  return val;
+}
+
+function validate(val, constraints = {}) {
+  if (val === undefined || val === null || val === '') {
+    return { ok: false, reason: 'missing' };
+  }
+  const str = String(val);
+  if (constraints.min_length !== undefined && str.length < constraints.min_length) {
+    return { ok: false, reason: 'min_length' };
+  }
+  if (constraints.no_generic_terms) {
+    const terms = Array.isArray(constraints.no_generic_terms)
+      ? constraints.no_generic_terms
+      : ['tbc', 'tbd', 'n/a', 'na', 'none', 'unknown', 'owner', 'manager', 'staff'];
+    const lower = str.toLowerCase();
+    if (terms.map((t) => t.toLowerCase()).includes(lower)) {
+      return { ok: false, reason: 'generic' };
+    }
+  }
+  return { ok: true };
+}
+
+async function applyIntent(tradecard = {}, opts = {}) {
   const { allow, doc } = cached || loadIntent();
   const fields = {};
   const sent_keys = [];
   const dropped_empty = [];
   const dropped_unknown = [];
+  const audit = [];
 
-  for (const [key, rawVal] of Object.entries(tradecard || {})) {
-    if (!allow.has(key)) {
-      dropped_unknown.push(key);
-      continue;
-    }
-    let val = rawVal;
-    if (val === undefined || val === null) {
-      dropped_empty.push(key);
-      continue;
-    }
+  const keys = Array.from(allow);
 
-    let transforms = doc[key]?.transform || doc[key]?.transforms;
-    if (!Array.isArray(transforms)) transforms = transforms ? [transforms] : [];
+  for (const key of keys) {
+    const rule = doc[key] || {};
+    const sourcePath = rule.source || key;
+    let val = resolvePath(tradecard, sourcePath);
+    let source = 'tradecard';
 
-    if (Array.isArray(val)) {
-      if (transforms.includes('csv') || transforms.includes('csv(array)')) {
-        val = val
-          .flatMap((v) => {
-            if (v === undefined || v === null) return [];
-            if (Array.isArray(v)) return v;
-            return [v];
-          })
-          .map((v) => (typeof v === 'string' ? v : String(v)))
-          .map((v) => v.trim())
-          .filter(Boolean)
-          .join(',');
-      } else {
-        val = val[0];
+    const transforms = Array.isArray(rule.transforms)
+      ? rule.transforms
+      : rule.transforms ? [rule.transforms] : [];
+    val = applyTransforms(val, transforms);
+
+    let { ok, reason } = validate(val, rule.constraints || {});
+
+    if (!ok) {
+      if (rule.when_missing === 'constant' && typeof rule.constant === 'string') {
+        val = applyTransforms(rule.constant, transforms);
+        ({ ok, reason } = validate(val, rule.constraints || {}));
+        source = 'tradecard';
+      } else if (rule.when_missing === 'llm' && opts.infer) {
+        try {
+          const inferred = await inferTradecard(tradecard, [key]);
+          let infVal = resolvePath(inferred, sourcePath) ?? resolvePath(inferred, key) ?? inferred[key];
+          if (infVal && typeof infVal === 'object' && 'value' in infVal) infVal = infVal.value;
+          val = applyTransforms(infVal, transforms);
+          ({ ok, reason } = validate(val, rule.constraints || {}));
+          source = 'llm';
+        } catch {
+          // ignore inference errors
+        }
       }
     }
 
-    if (typeof val === 'string') {
-      if (transforms.includes('trim')) val = val.trim();
-      if (transforms.includes('lower')) val = val.toLowerCase();
-      if (transforms.some((t) => t.startsWith('digits'))) {
-        val = val.replace(/[^+\d]/g, '');
-      }
-    } else if (typeof val === 'number' || typeof val === 'boolean') {
-      val = String(val);
-    } else if (val && typeof val === 'object') {
-      val = '';
-    }
-
-    if (typeof val === 'string' && transforms.length === 0) {
-      val = val.trim();
-    }
-
-    if (val === '' || val === undefined) {
+    if (ok && val !== '' && val !== undefined) {
+      fields[key] = val;
+      sent_keys.push(key);
+      audit.push({ key, status: 'sent', source, len: String(val).length });
+    } else {
       dropped_empty.push(key);
-      continue;
+      audit.push({ key, status: ok ? 'missing' : 'invalid', reason, source, len: val ? String(val).length : 0 });
     }
-
-    fields[key] = val;
-    sent_keys.push(key);
   }
 
-  return { fields, sent_keys, dropped_empty, dropped_unknown };
+  return { fields, sent_keys, dropped_empty, dropped_unknown, audit };
 }
 
 module.exports = { loadIntent, applyIntent };


### PR DESCRIPTION
## Summary
- expand `applyIntent` to resolve fields from intent map with transforms, validation, and optional LLM backfill
- surface intent audit stats in `/api/build` and pass inference flag

## Testing
- `npm test` *(fails: Cannot find module 'js-yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a85be5b8fc832aa37202219569bbd2