### PR TITLE
Add intent schema audit utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "commonjs",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "audit:intent": "node scripts/audit-intent.js"
   },
   "dependencies": {
     "cheerio": "^1.1.2",

--- a/scripts/audit-intent.js
+++ b/scripts/audit-intent.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const YAML = require('yaml');
+const http = require('http');
+
+// Load and expand intent map
+const raw = fs.readFileSync('config/field_intent_map.yaml', 'utf8');
+const parsed = YAML.parse(raw);
+const intentAllow = new Set();
+Object.keys(parsed || {}).forEach((key) => {
+  if (key.includes('service_{i}_')) {
+    [1, 2, 3].forEach((i) => intentAllow.add(key.replace('{i}', i)));
+  } else {
+    intentAllow.add(key);
+  }
+});
+
+// Build ACF schema allow set
+const identityFields = [
+  'business_name',
+  'website_url',
+  'email',
+  'phone',
+  'logo_url',
+  'address',
+  'state',
+  'suburb',
+  'abn',
+  'owner_name',
+  'role_title',
+  'headshot_url',
+  'website',
+  'location_label',
+  'services',
+  'uri_phone',
+  'uri_email',
+  'uri_sms',
+  'uri_whatsapp',
+  'address_uri'
+];
+const socialPlatforms = [
+  'facebook',
+  'instagram',
+  'linkedin',
+  'twitter',
+  'youtube',
+  'tiktok',
+  'pinterest'
+];
+const testimonialFields = [
+  'quote',
+  'reviewer',
+  'location',
+  'source_label',
+  'source_url',
+  'job_type'
+];
+const trustFields = [
+  'qr_text',
+  'google_rating',
+  'google_review_count',
+  'google_review_url',
+  'review_button_link',
+  'profile_video_url',
+  'contact_form',
+  'vcf_url'
+];
+const themeFields = ['primary_color', 'accent_color'];
+const serviceFields = [
+  'title',
+  'subtitle',
+  'description',
+  'image_url',
+  'price',
+  'price_note',
+  'cta_label',
+  'cta_link',
+  'delivery_modes',
+  'inclusion_1',
+  'inclusion_2',
+  'inclusion_3',
+  'video_url',
+  'tags',
+  'service_tags'
+];
+const services = [];
+[1, 2, 3].forEach((i) => {
+  serviceFields.forEach((f) => services.push(`service_${i}_${f}`));
+});
+
+const schemaAllow = new Set([
+  ...identityFields.map((f) => `identity_${f}`),
+  ...socialPlatforms.map((p) => `social_links_${p}`),
+  'business_description',
+  'service_areas_csv',
+  ...testimonialFields.map((f) => `testimonial_${f}`),
+  ...trustFields.map((f) => `trust_${f}`),
+  ...themeFields.map((f) => `theme_${f}`),
+  ...services
+]);
+
+// Categorisation
+function categorize(key) {
+  if (key.startsWith('identity_')) return 'identity';
+  if (key.startsWith('social_links_')) return 'socials';
+  if (key.startsWith('service_')) return 'services';
+  if (key.startsWith('testimonial_')) return 'testimonials';
+  if (key.startsWith('trust_') || key.startsWith('theme_')) return 'trust/theme';
+  return 'misc';
+}
+
+const categories = ['identity', 'socials', 'services', 'testimonials', 'trust/theme', 'misc'];
+const stats = {};
+categories.forEach((c) => {
+  stats[c] = {
+    category: c,
+    schema: 0,
+    intent: 0,
+    intersection: 0,
+    missing_in_intent: 0,
+    extra_in_intent: 0
+  };
+});
+
+// Count intent keys
+intentAllow.forEach((key) => {
+  const cat = categorize(key);
+  stats[cat].intent++;
+});
+
+// Count schema keys and intersections/missing
+schemaAllow.forEach((key) => {
+  const cat = categorize(key);
+  stats[cat].schema++;
+  if (intentAllow.has(key)) {
+    stats[cat].intersection++;
+  } else {
+    stats[cat].missing_in_intent++;
+  }
+});
+
+// Count extras in intent not in schema
+intentAllow.forEach((key) => {
+  if (!schemaAllow.has(key)) {
+    const cat = categorize(key);
+    stats[cat].extra_in_intent++;
+  }
+});
+
+const total = {
+  category: 'TOTAL',
+  schema: schemaAllow.size,
+  intent: intentAllow.size,
+  intersection: [...schemaAllow].filter((k) => intentAllow.has(k)).length,
+  missing_in_intent: [...schemaAllow].filter((k) => !intentAllow.has(k)).length,
+  extra_in_intent: [...intentAllow].filter((k) => !schemaAllow.has(k)).length
+};
+
+console.table([total, ...categories.map((c) => stats[c])]);
+
+// Optional run mode
+const runIndex = process.argv.indexOf('--run');
+if (runIndex !== -1) {
+  const target = process.argv[runIndex + 1];
+  if (!target) {
+    console.error('Missing target URL after --run');
+    process.exit(1);
+  }
+  const url = `http://localhost:3000/api/build?url=${encodeURIComponent(target)}&push=1&debug=1`;
+  http
+    .get(url, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          const sent = Array.isArray(json.sent_keys) ? json.sent_keys : [];
+          console.log('sent_keys count:', sent.length);
+          const missingAllowed = [...schemaAllow].filter((k) => !sent.includes(k));
+          const extraSent = sent.filter((k) => !schemaAllow.has(k));
+          console.log('missing allowed keys:', missingAllowed.slice(0, 10));
+          console.log('extra sent keys:', extraSent.slice(0, 10));
+        } catch (err) {
+          console.error('Invalid JSON response:', err.message);
+        }
+      });
+    })
+    .on('error', (err) => {
+      console.error('HTTP error:', err.message);
+    });
+}


### PR DESCRIPTION
## Summary
- add `scripts/audit-intent.js` to compare allowed intent keys with ACF schema
- expose `npm run audit:intent`

## Testing
- `npm test` *(fails: Cannot find module 'js-yaml')*
- `node scripts/audit-intent.js` *(fails: Cannot find module 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a862fb9d7c832a816fb8c45fec051a