### PR TITLE
feat: add hint-based LLM resolver and intent pipeline

### DIFF
--- a/api/build2.js
+++ b/api/build2.js
@@ -1,0 +1,5 @@
+// api/build2.js
+// Legacy route forwarding to /api/build
+
+module.exports = require('./build');
+

--- a/lib/acf_contract.js
+++ b/lib/acf_contract.js
@@ -1,91 +1,137 @@
-const identityFields = [
-  'business_name',
-  'website_url',
-  'email',
-  'phone',
-  'logo_url',
-  'address',
-  'state',
-  'suburb',
-  'abn',
-  'owner_name',
-  'role_title',
-  'headshot_url',
-  'website',
-  'location_label',
-  'services',
-  'uri_phone',
-  'uri_email',
-  'uri_sms',
-  'uri_whatsapp',
-  'address_uri'
-];
+// lib/acf_contract.js
+// Provides allowlist keys for ACF fields used during intent resolution.
 
-const socialPlatforms = [
-  'facebook',
-  'instagram',
-  'linkedin',
-  'twitter',
-  'youtube',
-  'tiktok',
-  'pinterest'
-];
+let cached;
 
-const testimonialFields = [
-  'quote',
-  'reviewer',
-  'location',
-  'source_label',
-  'source_url',
-  'job_type'
-];
+function expandServiceWildcards(list = []) {
+  const out = [];
+  for (const key of list) {
+    const m = key.match(/^service_\*_(.+)$/);
+    if (m) {
+      for (let i = 1; i <= 3; i++) out.push(`service_${i}_${m[1]}`);
+    } else {
+      out.push(key);
+    }
+  }
+  return out;
+}
 
-const trustFields = [
-  'qr_text',
-  'google_rating',
-  'google_review_count',
-  'google_review_url',
-  'review_button_link',
-  'profile_video_url',
-  'contact_form',
-  'vcf_url'
-];
+// Fallback allowlist used when the remote endpoint is unavailable.
+const FALLBACK = (() => {
+  const identityFields = [
+    'business_name',
+    'website_url',
+    'email',
+    'phone',
+    'logo_url',
+    'address',
+    'state',
+    'suburb',
+    'abn',
+    'owner_name',
+    'role_title',
+    'headshot_url',
+    'website',
+    'location_label',
+    'services',
+    'uri_phone',
+    'uri_email',
+    'uri_sms',
+    'uri_whatsapp',
+    'address_uri'
+  ];
 
-const themeFields = ['primary_color', 'accent_color'];
+  const socialPlatforms = [
+    'facebook',
+    'instagram',
+    'linkedin',
+    'twitter',
+    'youtube',
+    'tiktok',
+    'pinterest'
+  ];
 
-const serviceFields = [
-  'title',
-  'subtitle',
-  'description',
-  'image_url',
-  'price',
-  'price_note',
-  'cta_label',
-  'cta_link',
-  'delivery_modes',
-  'inclusion_1',
-  'inclusion_2',
-  'inclusion_3',
-  'video_url',
-  'tags',
-  'service_tags',
-  'panel_tag'
-];
+  const testimonialFields = [
+    'quote',
+    'reviewer',
+    'location',
+    'source_label',
+    'source_url',
+    'job_type'
+  ];
 
-const services = [];
-[1, 2, 3].forEach((i) => {
-  serviceFields.forEach((f) => services.push(`service_${i}_${f}`));
-});
+  const trustFields = [
+    'qr_text',
+    'google_rating',
+    'google_review_count',
+    'google_review_url',
+    'review_button_link',
+    'profile_video_url',
+    'contact_form',
+    'vcf_url'
+  ];
 
-const acfContract = [
-  ...identityFields.map((f) => `identity_${f}`),
-  ...socialPlatforms.map((p) => `social_links_${p}`),
-  'business_description',
-  'service_areas_csv',
-  ...testimonialFields.map((f) => `testimonial_${f}`),
-  ...trustFields.map((f) => `trust_${f}`),
-  ...themeFields.map((f) => `theme_${f}`),
-  ...services
-];
+  const themeFields = ['primary_color', 'accent_color'];
 
-module.exports = { acfContract };
+  const serviceFields = [
+    'title',
+    'subtitle',
+    'description',
+    'image_url',
+    'price',
+    'price_note',
+    'cta_label',
+    'cta_link',
+    'delivery_modes',
+    'inclusion_1',
+    'inclusion_2',
+    'inclusion_3',
+    'video_url',
+    'tags',
+    'service_tags',
+    'panel_tag'
+  ];
+
+  const services = [];
+  for (let i = 1; i <= 3; i++) {
+    for (const f of serviceFields) services.push(`service_${i}_${f}`);
+  }
+
+  return [
+    ...identityFields.map((f) => `identity_${f}`),
+    ...socialPlatforms.map((p) => `social_links_${p}`),
+    'business_description',
+    'service_areas_csv',
+    ...testimonialFields.map((f) => `testimonial_${f}`),
+    ...trustFields.map((f) => `trust_${f}`),
+    ...themeFields.map((f) => `theme_${f}`),
+    ...services
+  ];
+})();
+
+async function fetchRemoteAllowlist() {
+  const url = process.env.ACF_CONTRACT_URL;
+  if (!url) return null;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    let list;
+    if (Array.isArray(data)) list = data;
+    else if (Array.isArray(data?.fields)) list = data.fields;
+    else list = [];
+    return expandServiceWildcards(list);
+  } catch {
+    return null;
+  }
+}
+
+async function getAllowKeys() {
+  if (cached) return cached;
+  const remote = await fetchRemoteAllowlist();
+  cached = Array.isArray(remote) && remote.length ? remote : FALLBACK;
+  return cached;
+}
+
+module.exports = { getAllowKeys };
+

--- a/lib/hints.js
+++ b/lib/hints.js
@@ -1,0 +1,92 @@
+// lib/hints.js
+// Extract deterministic hints from raw crawl data.
+
+function uniq(arr) {
+  return Array.from(new Set(arr.filter(Boolean)));
+}
+
+function cleanPhone(p) {
+  if (!p) return null;
+  const digits = p.replace(/[^\d+]/g, '');
+  return digits.startsWith('+') ? '+' + digits.replace(/[^\d]/g, '') : digits;
+}
+
+function extractHints(raw = {}) {
+  const anchors = Array.isArray(raw.anchors) ? raw.anchors : (Array.isArray(raw.links) ? raw.links.map((h) => ({ href: h })) : []);
+  const texts = [];
+  if (Array.isArray(raw.headings)) texts.push(...raw.headings);
+  if (Array.isArray(raw.paragraphs)) texts.push(...raw.paragraphs);
+
+  const emails = [];
+  const phones = [];
+  const socials = {};
+
+  for (const a of anchors) {
+    const href = (a && a.href) || a;
+    if (typeof href !== 'string') continue;
+    const low = href.toLowerCase();
+    if (low.startsWith('mailto:')) emails.push(href.replace(/^mailto:/i, '').trim());
+    if (low.startsWith('tel:')) phones.push(href.replace(/^tel:/i, '').trim());
+
+    if (low.includes('facebook.com')) socials.facebook = href;
+    else if (low.includes('instagram.com')) socials.instagram = href;
+    else if (low.includes('linkedin.com')) socials.linkedin = href;
+    else if (low.includes('twitter.com') || low.includes('x.com')) socials.twitter = href;
+    else if (low.includes('youtube.com') || low.includes('youtu.be')) socials.youtube = href;
+    else if (low.includes('tiktok.com')) socials.tiktok = href;
+    else if (low.includes('pinterest.')) socials.pinterest = href;
+  }
+
+  const blob = texts.join(' ');
+  const emailRe = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+  const phoneRe = /(?:\+?61|0)[\d\s\-()]{6,16}/g;
+
+  let m;
+  while ((m = emailRe.exec(blob)) !== null) emails.push(m[0]);
+  while ((m = phoneRe.exec(blob)) !== null) phones.push(m[0]);
+
+  const cleanPhones = uniq(phones.map(cleanPhone)).filter((p) => /^(?:\+?61|0)\d{8,10}$/.test(p));
+  const cleanEmails = uniq(emails.map((e) => e.toLowerCase()));
+
+  let logo_url = raw.meta?.icon || raw.meta?.['og:image'];
+  if (!logo_url && Array.isArray(raw.images)) {
+    const img = raw.images.find((im) => /logo/i.test(im.alt || im.src || im));
+    if (img) logo_url = img.src || img;
+  }
+
+  const jsonld = raw.jsonld || raw.schema;
+  const nodes = Array.isArray(jsonld) ? jsonld : (jsonld ? [jsonld] : []);
+  let name;
+  let website;
+  const service_titles = [];
+  const scanNode = (node) => {
+    const type = node && node['@type'];
+    const types = Array.isArray(type) ? type : [type];
+    if (types.some((t) => ['Organization', 'LocalBusiness', 'WebSite'].includes(t))) {
+      if (!name && typeof node.name === 'string') name = node.name;
+      if (!website && typeof node.url === 'string') website = node.url;
+    }
+    if (types.includes('Service') && typeof node.name === 'string') {
+      service_titles.push(node.name);
+    }
+    if (Array.isArray(node['@graph'])) node['@graph'].forEach(scanNode);
+    if (Array.isArray(node.hasPart)) node.hasPart.forEach(scanNode);
+  };
+  nodes.forEach(scanNode);
+
+  if (!name && raw.meta && typeof raw.meta['og:site_name'] === 'string') name = raw.meta['og:site_name'];
+  if (!website && raw.meta && typeof raw.meta.canonical === 'string') website = raw.meta.canonical;
+
+  return {
+    emails: cleanEmails,
+    phones: cleanPhones,
+    socials,
+    logo_url,
+    name,
+    website,
+    service_titles: uniq(service_titles).slice(0, 3)
+  };
+}
+
+module.exports = { extractHints };
+

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,22 +1,72 @@
-const { acfContract } = require('./acf_contract');
+const { getAllowKeys } = require('./acf_contract');
+const { extractHints } = require('./hints');
 const { resolveWithLLM } = require('./llm_resolver');
 
 async function applyIntent(tradecard, { raw, resolve = 'llm' } = {}) {
-  const allowKeys = acfContract;
-  const { fields, audit } = await resolveWithLLM({ raw, allowKeys });
-  const sent = Object.keys(fields);
-  return {
-    fields,
-    sent_keys: sent,
-    audit,
-    trace: [
-      {
-        stage: 'llm_resolve',
-        sent: sent.length,
-        sample_sent: sent.slice(0, 10)
-      }
-    ]
+  const allowKeys = await getAllowKeys();
+  const hints = extractHints(raw || {});
+
+  const deterministic = {};
+  const put = (k, v) => {
+    if (!allowKeys.includes(k)) return;
+    if (v === undefined || v === null) return;
+    const s = String(v).trim();
+    if (!s) return;
+    deterministic[k] = s;
   };
+
+  put('identity_business_name', hints.name || tradecard?.business?.name);
+  put('identity_website_url', hints.website || tradecard?.contacts?.website);
+  put('identity_email', hints.emails?.[0]);
+  put('identity_phone', hints.phones?.[0]);
+  put('identity_logo_url', hints.logo_url);
+  for (const [p, url] of Object.entries(hints.socials || {})) {
+    put(`social_links_${p}`, url);
+  }
+
+  let llm = {}, la = [];
+  if (resolve === 'llm') {
+    const r = await resolveWithLLM({ raw, allowKeys, hints });
+    llm = r.fields || {};
+    la = r.audit || [];
+  }
+
+  const fields = {};
+  const merge = (obj = {}) => {
+    for (const [k, v] of Object.entries(obj)) {
+      if (!allowKeys.includes(k)) continue;
+      if (v === undefined || v === null) continue;
+      const s = String(v).trim();
+      if (!s) continue;
+      fields[k] = s;
+    }
+  };
+  merge(deterministic);
+  merge(llm);
+
+  const sent_keys = Object.keys(fields);
+
+  const trace = [];
+  trace.push({
+    stage: 'hint_extract',
+    emails: hints.emails.length,
+    phones: hints.phones.length,
+    socials: Object.values(hints.socials || {}).filter(Boolean).length,
+    logo: !!hints.logo_url
+  });
+  trace.push({
+    stage: 'llm_resolve',
+    sent: Object.keys(llm).length,
+    sample_sent: Object.keys(llm).slice(0, 10)
+  });
+  trace.push({
+    stage: 'intent_coverage',
+    after: sent_keys.length,
+    sample_sent: sent_keys.slice(0, 10)
+  });
+
+  return { fields, sent_keys, audit: [...la], trace };
 }
 
 module.exports = { applyIntent };
+

--- a/lib/llm_resolver.js
+++ b/lib/llm_resolver.js
@@ -1,39 +1,29 @@
 // lib/llm_resolver.js
-// Resolve fields using an LLM based on raw crawl data.
+// Resolve fields using an LLM based on raw crawl data and extracted hints.
 
 const { tryParseAssistant } = require('./infer');
 
-function buildHints(raw = {}) {
-  const links = Array.isArray(raw.links) ? raw.links : [];
-  let phone, email;
-  for (const href of links) {
-    if (!phone && /^tel:/i.test(href)) {
-      phone = href.replace(/^tel:/i, '').trim();
-    }
-    if (!email && /^mailto:/i.test(href)) {
-      email = href.replace(/^mailto:/i, '').trim();
-    }
-    if (phone && email) break;
-  }
-  const hints = {};
-  if (phone) hints.AU_phone = phone;
-  if (email) hints.email = email;
-  if (raw.url) hints.url = raw.url;
-  return hints;
-}
-
-function compactRaw(raw = {}) {
+function pruneRaw(raw = {}) {
   const out = {};
   if (Array.isArray(raw.headings)) out.headings = raw.headings.slice(0, 20);
   if (Array.isArray(raw.paragraphs)) out.paragraphs = raw.paragraphs.slice(0, 20);
-  if (Array.isArray(raw.links)) out.links = raw.links.slice(0, 50);
-  if (Array.isArray(raw.images)) out.images = raw.images.slice(0, 30);
-  if (raw.meta !== undefined) out.meta = raw.meta;
-  if (raw.schema !== undefined) out.schema = raw.schema;
+  if (Array.isArray(raw.links) || Array.isArray(raw.anchors)) {
+    const links = Array.isArray(raw.anchors) ? raw.anchors : raw.links.map((l) => ({ href: l }));
+    out.links = links.slice(0, 50).map((l) => ({ href: l.href || '', text: l.text || '' }));
+  }
+  if (Array.isArray(raw.images)) {
+    out.images = raw.images.slice(0, 30).map((img) => ({ src: img.src || img, alt: img.alt || '' }));
+  }
+  if (raw.meta && typeof raw.meta.description === 'string') {
+    out.meta = { description: raw.meta.description };
+  }
+  if (raw.jsonld || raw.schema) {
+    out.jsonld = raw.jsonld || raw.schema;
+  }
   return out;
 }
 
-async function resolveWithLLM({ raw = {}, allowKeys = [] } = {}) {
+async function resolveWithLLM({ raw = {}, allowKeys = [], hints = {} } = {}) {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey || !Array.isArray(allowKeys) || allowKeys.length === 0) {
     return { fields: {}, audit: [] };
@@ -41,8 +31,8 @@ async function resolveWithLLM({ raw = {}, allowKeys = [] } = {}) {
 
   const user = {
     allowKeys,
-    hints: buildHints(raw),
-    raw: compactRaw(raw)
+    hints,
+    raw_pruned: pruneRaw(raw)
   };
 
   const controller = new AbortController();
@@ -63,7 +53,7 @@ async function resolveWithLLM({ raw = {}, allowKeys = [] } = {}) {
           {
             role: 'system',
             content:
-              'Return ONLY valid JSON; keys must be from allowKeys; values must be strings; omit empty.'
+              'Return ONLY valid JSON. Keys must be from allowKeys. Values must be strings. Omit empty.'
           },
           { role: 'user', content: JSON.stringify(user) }
         ]
@@ -106,3 +96,4 @@ async function resolveWithLLM({ raw = {}, allowKeys = [] } = {}) {
 }
 
 module.exports = { resolveWithLLM };
+

--- a/test/intent.read.test.js
+++ b/test/intent.read.test.js
@@ -1,8 +1,9 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { acfContract } = require('../lib/acf_contract');
+const { getAllowKeys } = require('../lib/acf_contract');
 
-test('acf contract includes core fields', () => {
-  assert.ok(acfContract.includes('identity_business_name'));
-  assert.ok(acfContract.includes('service_1_title'));
+test('acf contract includes core fields', async () => {
+  const keys = await getAllowKeys();
+  assert.ok(keys.includes('identity_business_name'));
+  assert.ok(keys.includes('service_1_title'));
 });

--- a/test/llm_resolver.test.js
+++ b/test/llm_resolver.test.js
@@ -26,7 +26,8 @@ test('resolveWithLLM returns allowed keys only', async () => {
   });
 
   const { fields, audit } = await resolveWithLLM({
-    tradecard: {},
+    raw: {},
+    hints: {},
     allowKeys: ['identity_business_name', 'identity_phone']
   });
   restore();


### PR DESCRIPTION
## Summary
- fetch ACF contract allow keys with service wildcards support
- extract business hints (contacts, socials, metadata) from raw crawl data
- enhance LLM resolver, intent merging and build flow; add build2 route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa600834fc832ab4d57bfb171e3c76