### PR TITLE
feat: add acceptance test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "commonjs",
   "scripts": {
     "test": "node --test",
-    "audit:intent": "node scripts/audit-intent.js"
+    "audit:intent": "node scripts/audit-intent.js",
+    "accept": "bash scripts/accept.sh",
+    "accept:target": "bash scripts/accept.sh $TARGET"
   },
   "dependencies": {
     "cheerio": "^1.1.2",

--- a/scripts/accept.sh
+++ b/scripts/accept.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE=${BASE:-http://localhost:3000}
+TARGET=${1:-https://poolboysco.com.au}
+MIN=${MIN_ACF_KEYS:-10}
+
+summary=()
+
+# Step 1: Health check
+health_json=$(curl -fsS "$BASE/api/health")
+if [[ $(echo "$health_json" | jq -r '.ok') != "true" ]]; then
+  echo "Health check failed: $health_json"
+  exit 1
+fi
+summary+=("health:ok")
+
+# Step 2: Resolve-only build
+build_json=$(curl -fsS "$BASE/api/build?url=$TARGET&resolve=llm&push=0&debug=1")
+llm_sent=$(echo "$build_json" | jq '(.debug.trace[]?|select(.stage=="llm_resolve")|.sent) // 0')
+cov_after=$(echo "$build_json" | jq '(.debug.trace[]?|select(.stage=="intent_coverage")|.after) // 0')
+if (( llm_sent <= 0 )); then
+  echo "llm_sent <= 0"
+  exit 1
+fi
+if (( cov_after <= 3 )); then
+  echo "cov_after <= 3"
+  exit 1
+fi
+summary+=("resolve:sent=$llm_sent" "cov=$cov_after")
+
+# Step 3: Push (guarded)
+if [[ -n "${WP_BASE:-}" && -n "${WP_BEARER:-}" ]]; then
+  push_json=$(curl -fsS -X POST "$BASE/api/build?url=$TARGET&resolve=llm&push=1&debug=1")
+  sent_keys_len=$(echo "$push_json" | jq '(.wordpress.details.steps[]?|select(.step=="acf_sync").sent_keys|length) // 0')
+  if (( sent_keys_len < MIN )); then
+    echo "sent_keys_len $sent_keys_len < MIN $MIN"
+    exit 1
+  fi
+  summary+=("push:sent=$sent_keys_len")
+else
+  echo "WP creds missing → skipping push step"
+  summary+=("push:skipped")
+fi
+
+printf '%s ' "${summary[@]}"
+echo


### PR DESCRIPTION
## Summary
- add automated acceptance test script to validate health, resolve-only builds, and optional push
- expose `accept` and `accept:target` npm scripts for one-command execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa6e6bbc4c832aa20094da644a111f