### PR TITLE
Route build through intent resolver and expose traces

### DIFF
--- a/api/openapi.json.js
+++ b/api/openapi.json.js
@@ -7,7 +7,7 @@ const SPEC = {
     title: "TradeCard Site Processor",
     version: "1.0.0",
     description:
-      "Deterministic site scraping, crawling, and TradeCard JSON builder. Returns structured data suitable for downstream inference."
+      "Deterministic site scraping, crawling, and TradeCard JSON builder. Returns structured data suitable for downstream processing."
   },
   servers: [
     {
@@ -77,13 +77,12 @@ const SPEC = {
       get: {
         operationId: "buildTradeCard",
         summary: "Build a TradeCard JSON from a site",
-        description: "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON. When infer=1 and OPENAI_API_KEY is set, attempts to infer business.description, services.list, service_areas, brand.tone, and testimonials.",
+        description: "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON.",
         parameters: [
           { name: "url", in: "query", required: true, schema: { type: "string", format: "uri" } },
           { name: "maxPages", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 50, default: 12 } },
           { name: "maxDepth", in: "query", required: false, schema: { type: "integer", minimum: 0, maximum: 5, default: 2 } },
           { name: "sameOrigin", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 1 } },
-          { name: "infer", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1 and OPENAI_API_KEY is set, infer missing fields (business.description, services.list, service_areas, brand.tone, testimonials)" },
           { name: "save", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 1 }, description: "If BOSTONOS_API_TOKEN is set, save to BostonOS when save=1" },
           { name: "push", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1 and WP_BASE/WP_BEARER are set, push TradeCard to WordPress" },
           { name: "debug", in: "query", required: false, schema: { type: "integer", enum: [0,1], default: 0 }, description: "When 1, include debug.trace with stage timings" }

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -17,8 +17,30 @@ async function applyIntent(tradecard, { raw, resolve = 'llm' } = {}) {
 
   if (resolve === 'llm') {
     const hints = extractHints(raw || {});
-    const { fields: llm, audit: la } = await resolveWithLLM({ raw, allowKeys: allow, hints });
-    for (const [k, v] of Object.entries(llm)) put(k, v);
+    trace.push({
+      stage: 'hint_extract',
+      emails: hints.emails.length,
+      phones: hints.phones.length,
+      socials: Object.values(hints.socials || {}).filter(Boolean).length,
+      logo: !!hints.logo_url
+    });
+
+    const { fields: llmFields, audit: la } = await resolveWithLLM({
+      raw,
+      allowKeys: allow,
+      hints
+    });
+    trace.push({
+      stage: 'llm_resolve',
+      sent: Object.keys(llmFields).length,
+      sample_sent: Object.keys(llmFields).slice(0, 10)
+    });
+    for (const [k, v] of Object.entries(llmFields)) put(k, v);
+    trace.push({
+      stage: 'intent_coverage',
+      after: Object.keys(fields).length,
+      sample_sent: Object.keys(fields).slice(0, 10)
+    });
     audit.push(...la);
   }
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "TradeCard Site Processor",
     "version": "1.0.0",
-    "description": "Deterministic site scraping, crawling, and TradeCard JSON builder. Returns structured data suitable for downstream inference."
+    "description": "Deterministic site scraping, crawling, and TradeCard JSON builder. Returns structured data suitable for downstream processing."
   },
   "servers": [
     { "url": "https://tradecard-api.vercel.app" }
@@ -54,13 +54,12 @@
       "get": {
         "operationId": "buildTradeCard",
         "summary": "Build a TradeCard JSON from a site",
-        "description": "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON. When infer=1 and OPENAI_API_KEY is set, attempts to infer business.description, services.list, service_areas, brand.tone, and testimonials.",
+        "description": "Calls the deterministic crawler and normalizes into a TradeCard-ready JSON.",
         "parameters": [
           { "name": "url", "in": "query", "required": true, "schema": { "type": "string", "format": "uri" } },
           { "name": "maxPages", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 50, "default": 12 } },
           { "name": "maxDepth", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 0, "maximum": 5, "default": 2 } },
           { "name": "sameOrigin", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 1 } },
-          { "name": "infer", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1 and OPENAI_API_KEY is set, infer missing fields (business.description, services.list, service_areas, brand.tone, testimonials)" },
           { "name": "save", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 1 }, "description": "If BOSTONOS_API_TOKEN is set, save to BostonOS when save=1" },
           { "name": "push", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1 and WP_BASE/WP_BEARER are set, push TradeCard to WordPress" },
           { "name": "debug", "in": "query", "required": false, "schema": { "type": "integer", "enum": [0,1], "default": 0 }, "description": "When 1, include debug.trace with stage timings" }

--- a/test/build_route.test.js
+++ b/test/build_route.test.js
@@ -4,7 +4,7 @@ const mockFetch = require('./helpers/mockFetch');
 const resetEnv = require('./helpers/resetEnv');
 const buildLib = require('../lib/build');
 
-test('build route performs crawl, inference, push', async () => {
+test('build route performs crawl, intent resolve, push', async () => {
   buildLib.crawlSite = async () => [{
     url: 'http://site.test',
     title: 'Site Title',
@@ -18,19 +18,28 @@ test('build route performs crawl, inference, push', async () => {
   resetEnv({ OPENAI_API_KEY: 'k', WP_BASE: 'http://wp', WP_BEARER: 't' });
   const restore = mockFetch({
     'https://api.openai.com/v1/chat/completions': [
-      { json: { choices: [ { message: { content: '{"business":{"description":{"value":"d","confidence":0.9}},"services":{"list":{"value":["s"],"confidence":0.8}}}' } } ] } },
-      { json: { choices: [ { message: { content: JSON.stringify({
-        identity_business_name: 'Biz',
-        identity_website_url: 'http://site.test',
-        identity_email: 'a@b.com',
-        identity_phone: '123',
-        business_description: 'Desc',
-        service_2_title: 'S1',
-        service_2_description: 'D1',
-        service_2_image_url: 'i1',
-        service_areas_csv: 'A',
-        social_links_facebook: 'fb'
-      }) } } ] } }
+      {
+        json: {
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  identity_business_name: 'Biz',
+                  identity_website_url: 'http://site.test',
+                  identity_email: 'a@b.com',
+                  identity_phone: '123',
+                  business_description: 'Desc',
+                  service_2_title: 'S1',
+                  service_2_description: 'D1',
+                  service_2_image_url: 'i1',
+                  service_areas_csv: 'A',
+                  social_links_facebook: 'fb'
+                })
+              }
+            }
+          ]
+        }
+      }
     ],
     'http://wp/wp-json/': { json: { routes: { '/custom/v1/acf-sync/(?P<id>\\d+)': { methods: ['POST'] } } } },
     'http://wp/wp-json/wp/v2/tradecard': { json: { id: 1 } },
@@ -39,23 +48,24 @@ test('build route performs crawl, inference, push', async () => {
   });
 
   const handler = require('../api/build');
-  const req = { query: { url: 'http://site.test', infer: '1', push: '1', debug: '1', maxPages: '1', maxDepth: '0' } };
+  const req = { query: { url: 'http://site.test', push: '1', debug: '1', maxPages: '1', maxDepth: '0' } };
   const res = { status(c) { this.statusCode = c; return this; }, json(o) { this.body = o; } };
   await handler(req, res);
   restore();
 
   assert.equal(res.statusCode, 200);
-  assert.equal(res.body.tradecard.business.description, 'd');
-  assert.deepEqual(res.body.tradecard.services.list, ['s']);
   assert.ok(res.body.wordpress.ok);
-  assert.ok(!res.body.needs_inference.includes('business.description'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'crawl'));
-  assert.ok(res.body.debug.trace.find(t => t.stage === 'infer_response'));
-  assert.ok(res.body.debug.trace.find(t => t.stage === 'infer_merge'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'intent_input'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'hint_extract'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'llm_resolve'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'intent_coverage'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'push' && t.step === 'acf_sync'));
   const steps = res.body.wordpress.details.steps;
   assert.deepEqual(steps.map(s => s.step), ['create','upload_logo','upload_hero','upload_image','upload_image','acf_sync']);
   assert.ok(steps[0].response.ok);
   const acf_step = steps.find(s => s.step === 'acf_sync');
   assert.equal(acf_step.response.status, 200);
+  assert.ok(Array.isArray(res.body.wordpress.details.acf_keys));
+  assert.ok(res.body.wordpress.details.acf_keys.length >= 1);
 });


### PR DESCRIPTION
## Summary
- route build endpoint through contract-bound intent resolver
- record hint, LLM, and coverage stages in intent traces
- drop legacy infer option and its OpenAPI references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8eaa9010832abc38997f3fa92244