### PR TITLE
MVF resolver: deterministic RAW→ACF ≥10 fields; guard only on push; single /api/build path

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,6 +1,5 @@
-const { getAllowKeys, aliases } = require('./acf_contract');
-const { extractHints } = require('./hints');
-const { resolveWithLLM } = require('./llm_resolver');
+const { getAllowKeys } = require('./acf_contract');
+const { resolveMVF } = require('./mvf_resolver');
 
 async function applyIntent(tradecard, { raw, resolve = 'llm' } = {}) {
   const allow = getAllowKeys();
@@ -9,47 +8,35 @@ async function applyIntent(tradecard, { raw, resolve = 'llm' } = {}) {
   const trace = [];
   const audit = [];
 
-  function put(k, v) {
-    const key = allow.has(k) ? k : aliases[k];
-    if (!key || !allow.has(key)) return;
+  const put = (k, v) => {
+    if (!allow.has(k)) return;
     const s = (v == null ? '' : String(v)).trim();
     if (!s) return;
-    fields[key] = s;
-    sent.add(key);
-  }
+    fields[k] = s;
+    sent.add(k);
+  };
 
-  const hints = extractHints(raw || {});
-
-  put('identity_business_name', hints.name || tradecard?.business?.name);
-  put('identity_website_url', hints.website || tradecard?.contacts?.website);
-  put('identity_email', hints.emails?.[0]);
-  put('identity_phone', hints.phones?.[0]);
-  put('identity_logo_url', hints.logo_url);
-  for (const [k, v] of Object.entries(hints.socials || {})) {
-    put(`social_links_${k}`, v);
-  }
-
+  // 1) Deterministic MVF baseline first
+  const mvf = resolveMVF({ raw: raw || {}, tradecard: tradecard || {}, allowKeys: allow });
+  for (const [k, v] of Object.entries(mvf.fields || {})) put(k, v);
+  audit.push(...(mvf.audit || []));
   trace.push({
-    stage: 'hint_extract',
-    emails: hints.emails?.length || 0,
-    phones: hints.phones?.length || 0,
-    socials: Object.values(hints.socials || {}).filter(Boolean).length,
-    logo: !!hints.logo_url,
-    services: (hints.service_titles || []).length
+    stage: 'det_resolve',
+    sent: Object.keys(mvf.fields || {}).length,
+    sample_sent: Object.keys(mvf.fields || {}).slice(0, 10)
   });
 
-  if (resolve === 'llm') {
-    const { fields: llm, audit: la } = await resolveWithLLM({
-      raw,
-      allowKeys: allow,
-      hints
-    });
-    for (const [k, v] of Object.entries(llm || {})) put(k, v);
-    audit.push(...la);
+  // 2) Optional LLM top-up ONLY if still below MIN
+  const min = Number(process.env.MIN_ACF_KEYS) || 10;
+  if (resolve === 'llm' && sent.size < min) {
+    const { resolveWithLLM } = require('./llm_resolver');
+    const llm = await resolveWithLLM({ raw: raw || {}, allowKeys: allow, hints: mvf.fields || {} });
+    for (const [k, v] of Object.entries(llm.fields || {})) put(k, v);
+    audit.push(...(llm.audit || []));
     trace.push({
       stage: 'llm_resolve',
-      sent: Object.keys(llm || {}).length,
-      sample_sent: Object.keys(llm || {}).slice(0, 10)
+      sent: Object.keys(llm.fields || {}).length,
+      sample_sent: Object.keys(llm.fields || {}).slice(0, 10)
     });
   }
 

--- a/lib/mvf_resolver.js
+++ b/lib/mvf_resolver.js
@@ -1,0 +1,221 @@
+// lib/mvf_resolver.js
+// Deterministic minimum viable fill resolver.
+// Maps raw crawl data to allowed ACF fields without using an LLM.
+
+function resolveMVF({ raw = {}, tradecard = {}, allowKeys = new Set() } = {}) {
+  const fields = {};
+  const audit = [];
+
+  function put(key, value) {
+    if (!allowKeys.has(key)) return;
+    const s = (value == null ? '' : String(value)).trim();
+    if (!s) return;
+    fields[key] = s;
+    audit.push({ key, source: 'mvf' });
+  }
+
+  const anchors = Array.isArray(raw.anchors)
+    ? raw.anchors.map((a) => ({
+        href: a?.href || '',
+        text: a?.text || ''
+      }))
+    : [];
+
+  const headings = Array.isArray(raw.headings)
+    ? raw.headings.map((h) => (typeof h === 'string' ? { text: h } : { text: h?.text || '' }))
+    : [];
+
+  const images = Array.isArray(raw.images)
+    ? raw.images.map((img) => ({
+        src: img?.src || img,
+        alt: img?.alt || ''
+      }))
+    : [];
+
+  const meta = raw.meta || {};
+  const jsonld = Array.isArray(raw.jsonld) ? raw.jsonld : [];
+
+  // email
+  for (const a of anchors) {
+    const href = a.href || '';
+    const text = a.text || '';
+    if (href.startsWith('mailto:') || text.includes('@')) {
+      const candidate = href.startsWith('mailto:') ? href.slice(7) : text;
+      const match = candidate.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+      if (match) {
+        put('identity_email', match[0].toLowerCase());
+        break;
+      }
+    }
+  }
+
+  // phone
+  for (const a of anchors) {
+    const href = a.href || '';
+    const text = a.text || '';
+    if (href.startsWith('tel:') || /\d/.test(text)) {
+      const candidate = href.startsWith('tel:') ? href.slice(4) : text;
+      const match = candidate.match(/\+?\d[\d\s()-]{7,}/);
+      if (match) {
+        let num = match[0].replace(/[^\d+]/g, '');
+        if (num.startsWith('0')) {
+          num = '+61' + num.slice(1);
+        } else if (!num.startsWith('+')) {
+          num = '+' + num;
+        }
+        put('identity_phone', num);
+        break;
+      }
+    }
+  }
+
+  // socials
+  const socialHosts = {
+    facebook: 'facebook',
+    instagram: 'instagram',
+    linkedin: 'linkedin',
+    'x.com': 'twitter',
+    twitter: 'twitter',
+    youtube: 'youtube',
+    'youtu.be': 'youtube',
+    tiktok: 'tiktok',
+    pinterest: 'pinterest'
+  };
+  const seenSocial = new Set();
+  for (const a of anchors) {
+    try {
+      const url = new URL(a.href);
+      const host = url.hostname.toLowerCase();
+      for (const key of Object.keys(socialHosts)) {
+        if (host.includes(key)) {
+          const plat = socialHosts[key];
+          if (!seenSocial.has(plat)) {
+            put(`social_links_${plat}`, url.href);
+            seenSocial.add(plat);
+          }
+          break;
+        }
+      }
+    } catch {
+      // ignore invalid URLs
+    }
+  }
+
+  // logo_url
+  if (typeof meta['og:image'] === 'string') {
+    put('identity_logo_url', meta['og:image']);
+  } else {
+    const img = images.find((i) => /logo|brand/i.test(i.alt || ''));
+    if (img && img.src) put('identity_logo_url', img.src);
+  }
+
+  // name
+  let name;
+  for (const obj of jsonld) {
+    const types = Array.isArray(obj['@type']) ? obj['@type'] : [obj['@type']];
+    if (
+      types.some((t) =>
+        String(t).toLowerCase().match(/^(organization|website|localbusiness)$/)
+      ) &&
+      obj.name
+    ) {
+      name = obj.name;
+      break;
+    }
+  }
+  if (!name && typeof meta['og:site_name'] === 'string') {
+    name = meta['og:site_name'];
+  }
+  if (!name && tradecard?.business?.name) {
+    name = tradecard.business.name;
+  }
+  if (name) put('identity_business_name', name);
+
+  // website
+  let website;
+  for (const obj of jsonld) {
+    if (obj.url) {
+      website = obj.url;
+      break;
+    }
+  }
+  if (!website && typeof meta.canonical === 'string') {
+    website = meta.canonical;
+  }
+  if (!website && typeof meta['og:url'] === 'string') {
+    website = meta['og:url'];
+  }
+  if (!website && tradecard?.contacts?.website) {
+    website = tradecard.contacts.website;
+  }
+  if (website) put('identity_website_url', website);
+
+  // service_1_title
+  const serviceRe =
+    /(service|repair|install|inspection|quote|booking|clean|maintenance|pool|aircon|fence|paint|build)/i;
+  let serviceIdx = -1;
+  for (let i = 0; i < headings.length; i++) {
+    const t = (headings[i].text || '').trim();
+    if (t.length >= 2 && t.length <= 60 && serviceRe.test(t)) {
+      put('service_1_title', t);
+      serviceIdx = i;
+      break;
+    }
+  }
+
+  // service_1_description
+  if (serviceIdx >= 0) {
+    const parts = [];
+    if (headings[serviceIdx + 1]?.text)
+      parts.push(headings[serviceIdx + 1].text);
+    if (headings[serviceIdx + 2]?.text)
+      parts.push(headings[serviceIdx + 2].text);
+    for (const a of anchors) {
+      if (parts.length >= 2) break;
+      const t = (a.text || '').trim();
+      if (t) parts.push(t);
+    }
+    const desc = parts.join(' ').slice(0, 200).trim();
+    if (desc) put('service_1_description', desc);
+  }
+
+  // business_description
+  const ignoreHeadings = /^(home|contact|about|services?|menu|navigation|search)$/i;
+  const bdParts = [];
+  for (const h of headings) {
+    const t = (h.text || '').trim();
+    if (!t || ignoreHeadings.test(t)) continue;
+    bdParts.push(t);
+    if (bdParts.length >= 2) break;
+  }
+  if (bdParts.length) {
+    const bd = bdParts.join('. ').slice(0, 240).trim();
+    if (bd) put('business_description', bd);
+  }
+
+  // service_areas_csv
+  const areaCandidates = new Set();
+  const areaRe = /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\b/g;
+  function collectAreas(text) {
+    if (!text) return;
+    let m;
+    while ((m = areaRe.exec(text))) {
+      const token = m[1];
+      if (
+        !ignoreHeadings.test(token) &&
+        !serviceRe.test(token.toLowerCase())
+      ) {
+        areaCandidates.add(token);
+      }
+    }
+  }
+  headings.forEach((h) => collectAreas(h.text));
+  anchors.forEach((a) => collectAreas(a.text));
+  if (areaCandidates.size) {
+    put('service_areas_csv', Array.from(areaCandidates).join(','));
+  }
+
+  return { fields, audit };
+}
+
+module.exports = { resolveMVF };

--- a/test/build_route.test.js
+++ b/test/build_route.test.js
@@ -57,7 +57,7 @@ test('build route performs crawl, intent resolve, push', async () => {
   assert.ok(res.body.wordpress.ok);
   assert.ok(res.body.debug.trace.find(t => t.stage === 'crawl'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'intent_input'));
-  assert.ok(res.body.debug.trace.find(t => t.stage === 'hint_extract'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'det_resolve'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'llm_resolve'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'intent_coverage'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'push' && t.step === 'acf_sync'));


### PR DESCRIPTION
## Summary
- add deterministic mvf resolver mapping crawl RAW into contract-allowed ACF fields
- resolve MVF before optional LLM top-up in intent flow
- route /api/build assembles RAW, traces input, and guards thin payload only on push

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab1ecd53c832a8e9613454df4a6a9