### PR TITLE
fix: correct trust_award_link field alias

### DIFF
--- a/config/acf_contract.yaml
+++ b/config/acf_contract.yaml
@@ -50,7 +50,7 @@ allow:
   - trust_contact_form
   - trust_vcf_url
   - trust_award
-  - trsut_award_link
+  - trust_award_link
   - service_2_title
   - service_2_subtitle
   - service_2_image_url

--- a/lib/acf_contract.js
+++ b/lib/acf_contract.js
@@ -8,6 +8,7 @@ const YAML = require('yaml');
 
 const aliases = {
   trust_award_link: 'trsut_award_link',
+  trsut_award_link: 'trust_award_link',
   service_3_inclusion_3: 'service_3_Inclusion_3'
 };
 


### PR DESCRIPTION
## Summary
- rename `trsut_award_link` to `trust_award_link` in ACF config
- map both `trsut_award_link` and `trust_award_link` to the same field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aae198523c832ab232460ff7136951