### PR TITLE
chore: allow service panel fields

### DIFF
--- a/config/acf_contract.yaml
+++ b/config/acf_contract.yaml
@@ -51,6 +51,21 @@ allow:
   - trust_vcf_url
   - trust_award
   - trsut_award_link
+  - service_1_title
+  - service_1_subtitle
+  - service_1_image_url
+  - service_1_price_note
+  - service_1_description
+  - service_1_cta_label
+  - service_1_cta_link
+  - service_1_delivery_modes
+  - service_1_inclusion_1
+  - service_1_inclusion_2
+  - service_1_inclusion_3
+  - service_1_tags
+  - service_1_video_url
+  - service_1_price
+  - service_1_panel_tag
   - service_2_title
   - service_2_subtitle
   - service_2_image_url
@@ -65,6 +80,7 @@ allow:
   - service_2_tags
   - service_2_video_url
   - service_2_price
+  - service_2_panel_tag
   - service_3_title
   - service_3_subtitle
   - service_3_image_url
@@ -79,6 +95,7 @@ allow:
   - service_3_tags
   - service_3_video_url
   - service_3_price
+  - service_3_panel_tag
   # optionally include, if you choose to allow them:
   - account_company
   - account_subscription


### PR DESCRIPTION
## Summary
- allow service_1_* fields in ACF contract
- permit panel_tag on service_2 and service_3 panels

## Testing
- `npm test`
- `node - <<'NODE'
const fs=require('fs');
const allow= new Set([...fs.readFileSync('config/acf_contract.yaml','utf8').matchAll(/\s-\s([a-zA-Z0-9_]+)/g)].map(m=>m[1]));
const intent= fs.readFileSync('config/field_intent_map.yaml','utf8').split(/\n/).filter(l=>/^[a-zA-Z0-9_]+:/.test(l)).map(l=>l.split(':')[0]);
const extra=intent.filter(k=>!allow.has(k));
const missing=[...allow].filter(k=>!intent.includes(k));
console.log('extraCount',extra.length);
console.log('extraSample',extra.slice(0,20));
console.log('missingCount',missing.length);
console.log('missingSample',missing.slice(0,20));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68aae199a160832a8f439dbefa013b01