### PR TITLE
Expand ACF mapping for tradecard data

### DIFF
--- a/lib/mapAcf.js
+++ b/lib/mapAcf.js
@@ -66,24 +66,104 @@ function mapTradecardToAcf(tc = {}) {
   const dropped_unknown = [];
   const dropped_empty = [];
 
+  // Prepare service list
+  let services = [];
+  if (Array.isArray(tc.services)) services = tc.services;
+  else if (Array.isArray(tc.services?.list)) services = tc.services.list;
+  services = services.filter((s) => s && typeof s === 'object');
+
   // Identity
-  addField(fields, 'identity_business_name', tc.business?.name, dropped_empty);
-  addField(fields, 'identity_website_url', tc.contacts?.website, dropped_empty);
+  addField(fields, 'identity_business_name', tc.business?.name || tc.identity_business_name, dropped_empty);
+  addField(fields, 'identity_owner_name', tc.identity_owner_name || tc.owner?.name, dropped_empty);
+  addField(
+    fields,
+    'identity_role_title',
+    tc.identity_role_title || tc.owner?.role || tc.owner?.title,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'identity_headshot_url',
+    tc.identity_headshot_url || tc.owner?.headshot_url || tc.owner?.headshot || tc.assets?.headshot,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'identity_suburb',
+    tc.identity_suburb || tc.business?.address?.suburb || tc.location?.suburb,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'identity_state',
+    tc.identity_state || tc.business?.address?.state || tc.location?.state,
+    dropped_empty
+  );
+  const address =
+    tc.identity_address || tc.business?.address?.full || tc.contacts?.address || tc.address?.full;
+  addField(fields, 'identity_address', address, dropped_empty);
+  addField(
+    fields,
+    'identity_address_uri',
+    tc.identity_address_uri || tc.contacts?.address_uri || tc.address?.uri,
+    dropped_empty
+  );
+  addField(fields, 'identity_abn', tc.identity_abn || tc.business?.abn, dropped_empty);
+  addField(fields, 'identity_insured', tc.identity_insured || tc.business?.insured, dropped_empty);
+  addField(
+    fields,
+    'identity_business_type',
+    tc.identity_business_type || tc.business?.type,
+    dropped_empty
+  );
+  addField(fields, 'identity_services', services.map((s) => s.title), dropped_empty);
+  addField(fields, 'identity_website_url', tc.contacts?.website || tc.identity_website_url, dropped_empty);
+  addField(fields, 'identity_website', tc.identity_website || tc.contacts?.website, dropped_empty);
 
-  const email = normalizeEmail(tc.contacts?.emails?.[0]);
-  if (email) fields.identity_email = email; else if (tc.contacts?.emails?.[0] !== undefined) dropped_empty.push('identity_email');
+  const email = normalizeEmail(tc.contacts?.emails?.[0] || tc.identity_email);
+  if (email) fields.identity_email = email;
+  else if (tc.contacts?.emails?.[0] !== undefined || tc.identity_email !== undefined)
+    dropped_empty.push('identity_email');
 
-  const phone = normalizePhone(tc.contacts?.phones?.[0]);
-  if (phone) fields.identity_phone = phone; else if (tc.contacts?.phones?.[0] !== undefined) dropped_empty.push('identity_phone');
+  const phone = normalizePhone(tc.contacts?.phones?.[0] || tc.identity_phone);
+  if (phone) fields.identity_phone = phone;
+  else if (tc.contacts?.phones?.[0] !== undefined || tc.identity_phone !== undefined)
+    dropped_empty.push('identity_phone');
 
-  addField(fields, 'identity_logo_url', tc.assets?.logo, dropped_empty);
+  addField(fields, 'identity_logo_url', tc.assets?.logo || tc.identity_logo_url, dropped_empty);
+  addField(
+    fields,
+    'identity_uri_phone',
+    tc.identity_uri_phone || tc.contacts?.uri_phone || (phone ? `tel:${phone}` : undefined),
+    dropped_empty
+  );
+  addField(
+    fields,
+    'identity_uri_email',
+    tc.identity_uri_email || tc.contacts?.uri_email || (email ? `mailto:${email}` : undefined),
+    dropped_empty
+  );
+  addField(
+    fields,
+    'identity_uri_sms',
+    tc.identity_uri_sms || tc.contacts?.uri_sms || (phone ? `sms:${phone}` : undefined),
+    dropped_empty
+  );
+  addField(
+    fields,
+    'identity_uri_whatsapp',
+    tc.identity_uri_whatsapp ||
+      tc.contacts?.uri_whatsapp ||
+      (phone ? `https://wa.me/${phone.replace(/[^\d]/g, '')}` : undefined),
+    dropped_empty
+  );
 
   // Social links
   const socials = Array.isArray(tc.social) ? tc.social : [];
-  const platforms = ['facebook', 'instagram', 'linkedin', 'twitter', 'youtube', 'tiktok'];
-  for (const plat of platforms) {
-    const item = socials.find((s) => s.platform === plat);
-    addField(fields, `social_links_${plat}`, item?.url, dropped_empty);
+  for (const s of socials) {
+    const plat = String(s.platform || '').toLowerCase().trim();
+    if (!plat) continue;
+    addField(fields, `social_links_${plat}`, s.url, dropped_empty);
   }
 
   // Business description
@@ -100,11 +180,6 @@ function mapTradecardToAcf(tc = {}) {
   }
 
   // Services
-  let services = [];
-  if (Array.isArray(tc.services)) services = tc.services;
-  else if (Array.isArray(tc.services?.list)) services = tc.services.list;
-  services = services.filter((s) => s && typeof s === 'object');
-
   for (let i = 0; i < Math.min(3, services.length); i++) {
     const svc = services[i] || {};
     const idx = i + 1;
@@ -114,31 +189,93 @@ function mapTradecardToAcf(tc = {}) {
     addField(fields, `service_${idx}_image_url`, svc.image_url || svc.image, dropped_empty);
     addField(fields, `service_${idx}_cta_label`, svc.cta_label, dropped_empty);
     addField(fields, `service_${idx}_cta_link`, svc.cta_link, dropped_empty);
+    addField(fields, `service_${idx}_price_note`, svc.price_note, dropped_empty);
+    addField(fields, `service_${idx}_delivery_modes`, svc.delivery_modes, dropped_empty);
+    if (Array.isArray(svc.inclusions)) {
+      for (let j = 0; j < 3; j++) {
+        addField(fields, `service_${idx}_inclusion_${j + 1}`, svc.inclusions[j], dropped_empty);
+      }
+    } else {
+      addField(fields, `service_${idx}_inclusion_1`, svc.inclusion_1, dropped_empty);
+      addField(fields, `service_${idx}_inclusion_2`, svc.inclusion_2, dropped_empty);
+      addField(fields, `service_${idx}_inclusion_3`, svc.inclusion_3, dropped_empty);
+    }
+    addField(fields, `service_${idx}_tags`, svc.tags, dropped_empty);
+    addField(fields, `service_${idx}_video_url`, svc.video_url, dropped_empty);
+    addField(fields, `service_${idx}_price`, svc.price, dropped_empty);
+    addField(fields, `service_${idx}_panel_tag`, svc.panel_tag, dropped_empty);
   }
 
-  // Testimonials (if array of strings)
-  if (Array.isArray(tc.testimonials)) {
-    const testi = tc.testimonials.filter(Boolean);
-    for (let i = 0; i < Math.min(3, testi.length); i++) {
-      addField(fields, `testimonial_${i + 1}_quote`, testi[i], dropped_empty);
-    }
-  }
+  // Testimonial
+  const testimonialObj =
+    (tc.testimonial && typeof tc.testimonial === 'object' && tc.testimonial) ||
+    (Array.isArray(tc.testimonials)
+      ? tc.testimonials.find((t) => t && typeof t === 'object')
+      : null);
+  const testimonialQuote =
+    tc.testimonial_quote ||
+    testimonialObj?.quote ||
+    testimonialObj?.text ||
+    (Array.isArray(tc.testimonials) && typeof tc.testimonials[0] === 'string'
+      ? tc.testimonials[0]
+      : undefined);
+  addField(fields, 'testimonial_quote', testimonialQuote, dropped_empty);
+  addField(
+    fields,
+    'testimonial_reviewer',
+    tc.testimonial_reviewer || testimonialObj?.reviewer || testimonialObj?.name,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'testimonial_location',
+    tc.testimonial_location || testimonialObj?.location,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'testimonial_source_label',
+    tc.testimonial_source_label || testimonialObj?.source_label,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'testimonial_source_url',
+    tc.testimonial_source_url || testimonialObj?.source_url,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'testimonial_job_type',
+    tc.testimonial_job_type || testimonialObj?.job_type,
+    dropped_empty
+  );
 
   // Theme fields
-  addField(fields, 'theme_tone', tc.brand?.tone, dropped_empty);
-  if (Array.isArray(tc.brand?.colors)) {
-    addField(fields, 'theme_colors', tc.brand.colors, dropped_empty);
-  }
+  addField(
+    fields,
+    'theme_primary_color',
+    tc.theme_primary_color || tc.theme?.primary_color || tc.brand?.primary_color,
+    dropped_empty
+  );
+  addField(
+    fields,
+    'theme_accent_color',
+    tc.theme_accent_color || tc.theme?.accent_color || tc.brand?.accent_color,
+    dropped_empty
+  );
 
-  // Trust fields (if present as object or array)
+  // Trust fields
+  for (const [k, v] of Object.entries(tc)) {
+    if (k.startsWith('trust_')) addField(fields, k, v, dropped_empty);
+  }
   if (Array.isArray(tc.trust)) {
     for (let i = 0; i < Math.min(5, tc.trust.length); i++) {
       addField(fields, `trust_${i + 1}`, tc.trust[i], dropped_empty);
     }
   } else if (tc.trust && typeof tc.trust === 'object') {
     for (const [k, v] of Object.entries(tc.trust)) {
-      const key = `trust_${k}`;
-      addField(fields, key, v, dropped_empty);
+      addField(fields, `trust_${k}`, v, dropped_empty);
     }
   }
 


### PR DESCRIPTION
## Summary
- map additional identity fields and contact URIs
- dynamically handle social links and detailed service/testimonial data
- expose theme colors and trust fields from tradecard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaecba2150832ab8c402a535317d1f