### PR TITLE
feat: expand profile parsing and identity resolution

### DIFF
--- a/config/field_intent_map.yaml
+++ b/config/field_intent_map.yaml
@@ -99,6 +99,9 @@ identity_services:
   priority: optional
   tools: [site_scraper]
   fallback: false
+  constraints:
+    html_tag: div
+    class: tag
 
 identity_display_name:
   priority: derived

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -224,6 +224,53 @@ async function parse(html, pageUrl) {
   const uniqueEmails  = Array.from(new Set(emails));
   const uniquePhones  = Array.from(new Set(phones));
 
+  // Owner name/title/headshot
+  const ownerName =
+    $('.owner .name').first().text().trim() ||
+    $('[data-owner-name]').first().text().trim() ||
+    null;
+  const ownerTitle =
+    $('.owner .title').first().text().trim() ||
+    $('[data-owner-title]').first().text().trim() ||
+    null;
+  const headshotUrl =
+    $('.owner img').first().attr('src') ||
+    $('img[alt*="headshot" i]').first().attr('src') ||
+    null;
+
+  // Address/suburb/state/ABN/insurance text
+  const addrText = $('address').first().text() || $('.address').first().text() || '';
+  const addressFull = norm(addrText) || null;
+  let suburb, state;
+  if (addressFull) {
+    const parts = addressFull.split(',').map((p) => p.trim());
+    if (parts.length >= 2) {
+      suburb = parts[parts.length - 2];
+      const stMatch = /(NSW|QLD|VIC|WA|SA|TAS|ACT|NT)/.exec(parts[parts.length - 1]);
+      if (stMatch) state = stMatch[1];
+    }
+  }
+
+  const bodyText = $('body').text();
+  const abnMatch = /ABN\s*[:#-]?\s*([0-9\s]{9,20})/i.exec(bodyText);
+  const abn = abnMatch ? abnMatch[1].replace(/\s+/g, '') : null;
+  const insuredMatch = /(fully\s+insured[^\n]*|insurance[^\n]*)/i.exec(bodyText);
+  const insuredText = insuredMatch ? norm(insuredMatch[0]) : null;
+
+  // Contact URIs
+  let uriPhone, uriEmail, uriSms, uriWhatsapp, addressUri;
+  for (const href of links) {
+    const low = href.toLowerCase();
+    if (!uriEmail && low.startsWith('mailto:')) uriEmail = href;
+    if (!uriPhone && low.startsWith('tel:')) uriPhone = href;
+    if (!uriSms && low.startsWith('sms:')) uriSms = href;
+    if (!uriWhatsapp && (low.includes('wa.me') || low.includes('whatsapp'))) uriWhatsapp = href;
+    if (!addressUri && /(google\.com\/maps|goo\.gl\/maps|maps\.app\.goo\.gl)/.test(low)) addressUri = href;
+  }
+
+  // Service tags
+  const serviceTags = $('.tag').map((_, el) => norm($(el).text())).get().filter(Boolean);
+
   return {
     url: pageUrl,
     title,
@@ -236,6 +283,23 @@ async function parse(html, pageUrl) {
     text_blocks,
     social: uniqueSocials,
     contacts: { emails: uniqueEmails, phones: uniquePhones },
+    identity_owner_name: ownerName,
+    identity_role_title: ownerTitle,
+    identity_headshot_url: headshotUrl,
+    identity_suburb: suburb,
+    identity_state: state,
+    identity_abn: abn,
+    identity_insured: insuredText,
+    identity_address: addressFull,
+    identity_email: uniqueEmails[0] || null,
+    identity_phone: uniquePhones[0] || null,
+    identity_services: serviceTags,
+    identity_website_url: pageUrl,
+    identity_uri_phone: uriPhone,
+    identity_uri_email: uriEmail,
+    identity_uri_sms: uriSms,
+    identity_uri_whatsapp: uriWhatsapp,
+    identity_address_uri: addressUri,
   };
 }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -51,4 +51,54 @@ function pickBest(candidates = {}, targetKey = '', { min = 0.68 } = {}) {
   return { value, confidence: baseConf * bestScore, matched: bestKey };
 }
 
-module.exports = { similar, pickBest };
+function resolveIdentity(parsed = {}) {
+  const out = {};
+
+  const copy = (key) => {
+    if (parsed[key]) out[key] = parsed[key];
+  };
+
+  [
+    'identity_owner_name',
+    'identity_role_title',
+    'identity_headshot_url',
+    'identity_suburb',
+    'identity_state',
+    'identity_abn',
+    'identity_insured',
+    'identity_address',
+    'identity_email',
+    'identity_phone',
+    'identity_website_url',
+    'identity_uri_phone',
+    'identity_uri_email',
+    'identity_uri_sms',
+    'identity_uri_whatsapp',
+    'identity_address_uri'
+  ].forEach(copy);
+
+  if (Array.isArray(parsed.identity_services)) {
+    out.identity_services = parsed.identity_services
+      .map((s) => `<div class="tag">${s}</div>`)
+      .join('');
+  }
+
+  if (parsed.identity_website_url && !out.identity_website) {
+    try {
+      const u = new URL(parsed.identity_website_url);
+      out.identity_website = u.hostname.replace(/^www\./, '');
+      out.identity_website_url = u.toString();
+    } catch {
+      out.identity_website = parsed.identity_website_url.replace(/^https?:\/\//, '').replace(/^www\./, '');
+    }
+  }
+
+  if (!out.identity_address_uri && parsed.identity_address) {
+    out.identity_address_uri =
+      `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(parsed.identity_address)}`;
+  }
+
+  return out;
+}
+
+module.exports = { similar, pickBest, resolveIdentity };

--- a/test/fixtures/profile.html
+++ b/test/fixtures/profile.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+  <title>Biz</title>
+</head>
+<body>
+  <div class="owner">
+    <img src="http://biz.example.com/headshot.jpg" alt="Headshot">
+    <span class="name">Jane Doe</span>
+    <span class="title">Director</span>
+  </div>
+  <address>123 Street, Suburb, NSW 2000</address>
+  <div class="abn">ABN: 12 345 678 901</div>
+  <div class="insurance">Fully insured for all work</div>
+  <div class="contact">
+    <a href="tel:+610212345678">Call</a>
+    <a href="mailto:jane@example.com">Email</a>
+    <a href="sms:+610212345678">SMS</a>
+    <a href="https://wa.me/610212345678">WhatsApp</a>
+    <a href="https://maps.google.com/maps?q=123+Street,Suburb+NSW">Map</a>
+  </div>
+  <div class="services">
+    <div class="tag">Plumbing</div>
+    <div class="tag">Gas Fitting</div>
+  </div>
+</body>
+</html>

--- a/test/identity.resolve.test.js
+++ b/test/identity.resolve.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { parse } = require('../lib/parse');
+const { resolveIdentity } = require('../lib/resolve');
+
+test('raw profile resolves into full identity block', async () => {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures/profile.html'), 'utf8');
+  const parsed = await parse(html, 'http://biz.example.com');
+  const identity = resolveIdentity(parsed);
+
+  assert.equal(identity.identity_owner_name, 'Jane Doe');
+  assert.equal(identity.identity_role_title, 'Director');
+  assert.equal(identity.identity_headshot_url, 'http://biz.example.com/headshot.jpg');
+  assert.equal(identity.identity_suburb, 'Suburb');
+  assert.equal(identity.identity_state, 'NSW');
+  assert.equal(identity.identity_abn, '12345678901');
+  assert.equal(identity.identity_insured, 'Fully insured for all work');
+  assert.equal(identity.identity_address, '123 Street, Suburb, NSW 2000');
+  assert.equal(identity.identity_email, 'jane@example.com');
+  assert.equal(identity.identity_phone, '+610212345678');
+  assert.equal(
+    identity.identity_services,
+    '<div class="tag">Plumbing</div><div class="tag">Gas Fitting</div>'
+  );
+  assert.equal(identity.identity_website, 'biz.example.com');
+  assert.equal(identity.identity_website_url, 'http://biz.example.com/');
+  assert.ok(identity.identity_address_uri.includes('google.com/maps'));
+  assert.equal(identity.identity_uri_email, 'mailto:jane@example.com');
+  assert.equal(identity.identity_uri_phone, 'tel:+610212345678');
+  assert.equal(identity.identity_uri_sms, 'sms:+610212345678');
+  assert.equal(identity.identity_uri_whatsapp, 'https://wa.me/610212345678');
+});


### PR DESCRIPTION
## Summary
- capture owner, address, ABN, insurance, contact URIs and service tags during HTML scrape
- derive website/display and address map link while formatting service tags
- validate raw profile resolves into full identity block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aafce3dba8832a80c110e31fad7fbf