### PR TITLE
Add social link mapping with GMB fallback

### DIFF
--- a/config/field_intent_map.yaml
+++ b/config/field_intent_map.yaml
@@ -644,7 +644,7 @@ social_links_youtube:
     reject_placeholders: ["#", "/", ""]
     strip_query_params: ["utm_", "fbclid"]
     lowercase_except_protocol: true
-    must_contain: "youtube.com"
+    must_contain_any: ["youtube.com", "youtu.be"]
 
 business_description:
   priority: recommended

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -215,6 +215,7 @@ async function parse(html, pageUrl) {
       low.includes('linkedin.com')  ? 'linkedin'  :
       (low.includes('youtube.com') || low.includes('youtu.be')) ? 'youtube' :
       low.includes('tiktok.com')    ? 'tiktok'    :
+      low.includes('pinterest.')    ? 'pinterest' :
       null;
     if (platform) socials.push({ platform, url: href });
   }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -51,4 +51,53 @@ function pickBest(candidates = {}, targetKey = '', { min = 0.68 } = {}) {
   return { value, confidence: baseConf * bestScore, matched: bestKey };
 }
 
-module.exports = { similar, pickBest };
+function cleanSocialUrl(url = '', platform = '') {
+  try {
+    const u = new URL(String(url));
+    u.protocol = 'https:';
+    u.hash = '';
+    for (const key of Array.from(u.searchParams.keys())) {
+      if (key.startsWith('utm_') || key === 'fbclid') u.searchParams.delete(key);
+    }
+    const host = u.hostname.toLowerCase();
+    const path = u.pathname.toLowerCase().replace(/\/+$/, '');
+    const search = u.searchParams.toString().toLowerCase();
+    const out = `https://${host}${path}${search ? `?${search}` : ''}`;
+    const checks = {
+      facebook: /facebook\.com/,
+      instagram: /instagram\.com/,
+      linkedin: /linkedin\.com/,
+      pinterest: /pinterest\.com/,
+      tiktok: /tiktok\.com/,
+      twitter: /(x\.com|twitter\.com)/,
+      youtube: /(youtube\.com|youtu\.be)/
+    };
+    if (platform && checks[platform] && !checks[platform].test(out)) return null;
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function resolveSocialLinks(parsed = [], gmb_lookup = {}) {
+  const platforms = ['facebook', 'instagram', 'linkedin', 'pinterest', 'tiktok', 'twitter', 'youtube'];
+  const out = {};
+  const byPlat = new Map();
+  if (Array.isArray(parsed)) {
+    for (const s of parsed) {
+      const plat = String(s?.platform || '').toLowerCase();
+      const url = typeof s?.url === 'string' ? s.url.trim() : '';
+      if (!plat || !url || byPlat.has(plat)) continue;
+      byPlat.set(plat, url);
+    }
+  }
+  for (const plat of platforms) {
+    let url = byPlat.get(plat) || gmb_lookup[`social_links_${plat}`];
+    if (!url) continue;
+    const clean = cleanSocialUrl(url, plat);
+    if (clean) out[`social_links_${plat}`] = clean;
+  }
+  return out;
+}
+
+module.exports = { similar, pickBest, resolveSocialLinks };

--- a/test/fixtures/simple.html
+++ b/test/fixtures/simple.html
@@ -19,5 +19,11 @@
   <a href="mailto:info@example.com">mail</a>
   <a href="tel:+123456">phone</a>
   <a href="https://facebook.com/acme">fb</a>
+  <a href="https://instagram.com/acme">ig</a>
+  <a href="https://linkedin.com/company/acme">ln</a>
+  <a href="https://x.com/acme">tw</a>
+  <a href="https://youtu.be/ABC">yt</a>
+  <a href="https://tiktok.com/@acme">tt</a>
+  <a href="https://pinterest.com/acme">pin</a>
 </body>
 </html>

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -20,7 +20,10 @@ test('parse extracts canonical images, headings, socials, contacts', async () =>
   assert.deepEqual(page.headings.h3, ['H3']);
   assert.ok(page.images.every(u => u.startsWith('http://example.com/') && !u.includes('?') && !u.includes('#')));
   assert.equal(new Set(page.images).size, page.images.length);
-  assert.ok(page.social.find(s => s.platform === 'facebook'));
+  const plats = ['facebook','instagram','linkedin','twitter','youtube','tiktok','pinterest'];
+  for (const p of plats) {
+    assert.ok(page.social.find(s => s.platform === p), `missing ${p}`);
+  }
   assert.deepEqual(page.contacts.emails, ['info@example.com']);
   assert.deepEqual(page.contacts.phones, ['+123456']);
 });

--- a/test/resolve.social.test.js
+++ b/test/resolve.social.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { resolveSocialLinks } = require('../lib/resolve');
+
+test('resolveSocialLinks merges parsed socials with gmb fallback', () => {
+  const parsed = [
+    { platform: 'facebook', url: 'http://facebook.com/Acme?utm_source=fb&fbclid=123' },
+    { platform: 'instagram', url: 'https://instagram.com/acme' },
+    { platform: 'youtube', url: 'https://youtu.be/ABC' }
+  ];
+  const gmb = {
+    social_links_twitter: 'https://twitter.com/acme',
+    social_links_linkedin: 'https://linkedin.com/company/acme',
+    social_links_pinterest: 'https://pinterest.com/acme',
+    social_links_tiktok: 'https://tiktok.com/@acme'
+  };
+  const res = resolveSocialLinks(parsed, gmb);
+  assert.deepEqual(res, {
+    social_links_facebook: 'https://facebook.com/acme',
+    social_links_instagram: 'https://instagram.com/acme',
+    social_links_youtube: 'https://youtu.be/abc',
+    social_links_twitter: 'https://twitter.com/acme',
+    social_links_linkedin: 'https://linkedin.com/company/acme',
+    social_links_pinterest: 'https://pinterest.com/acme',
+    social_links_tiktok: 'https://tiktok.com/@acme'
+  });
+});


### PR DESCRIPTION
## Summary
- Parse anchor tags into platform-specific social arrays including Pinterest
- Resolve social links into `social_links_*` fields with GMB fallbacks and URL normalization
- Allow YouTube `youtu.be` links in field intent map and add comprehensive tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aafd1783a8832a8efdb3e7ebc63c33