### PR TITLE
Parse service panels with auto-fill and validation

### DIFF
--- a/config/field_intent_map.yaml
+++ b/config/field_intent_map.yaml
@@ -150,14 +150,14 @@ identity_website_url:
 # <full 02_service_panels.yaml from patch>
 # Common constraints for inclusions
 _inclusion_constraints: &_inclusion_constraints
+  min_length: 2
   reject_values:
     - "TBC"
     - "Coming Soon"
 
 # Common constraints for tags
 _tag_constraints: &_tag_constraints
-  must_start_with: "featured_"
-  no_underscores: true
+  allowed_values: ["featured service", "featured project", "featured product"]
   format: human_readable_single
 
 # Common constraints for price note
@@ -172,6 +172,7 @@ _price_note_constraints: &_price_note_constraints
 # Common constraints for price
 _price_constraints: &_price_constraints
   max_length: 6
+  regex: "^\\$?\\d+(?:\\.\\d{2})?$"
 
 # ===== Service 1 =====
 service_1_title:

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -16,6 +16,70 @@ function* extractImports(cssText = '') {
   let m; while ((m = re.exec(cssText)) !== null) yield m[1];
 }
 
+function resolveUrl(u, base) {
+  if (!u) return null;
+  try { return new URL(u, base).toString(); } catch { return null; }
+}
+
+function parseServicePanels($, base) {
+  const norm = (t) => (t || '').replace(/\s+/g, ' ').trim();
+  const services = [];
+  $('.service-panel').each((_, el) => {
+    if (services.length >= 3) return;
+    const $p = $(el);
+    const svc = {};
+    const img = $p.find('img').attr('src');
+    if (img) svc.image_url = resolveUrl(img, base);
+    const price = norm($p.find('.price').first().text());
+    if (price) svc.price = price;
+    const priceNote = norm($p.find('.price-note').first().text());
+    if (priceNote) svc.price_note = priceNote;
+    const cta = $p.find('.cta').first();
+    if (cta.length) {
+      const label = norm(cta.text());
+      if (label) svc.cta_label = label;
+      const href = cta.attr('href');
+      if (href) svc.cta_link = resolveUrl(href, base);
+    }
+    const modes = norm($p.find('.delivery-modes').first().text());
+    if (modes) svc.delivery_modes = modes.split(/[,|]/).map(norm).filter(Boolean).join(',');
+    const inclusions = $p.find('.inclusions li').map((_, li) => norm($(li).text())).get().filter(Boolean);
+    if (inclusions[0]) svc.inclusion_1 = inclusions[0];
+    if (inclusions[1]) svc.inclusion_2 = inclusions[1];
+    if (inclusions[2]) svc.inclusion_3 = inclusions[2];
+    const video = $p.find('video').attr('src');
+    if (video) svc.video_url = resolveUrl(video, base);
+    let tags = [];
+    tags = tags.concat($p.find('.tags li').map((_, li) => norm($(li).text())).get());
+    const dataTags = ($p.attr('data-tags') || '').split(',').map(norm).filter(Boolean);
+    tags = Array.from(new Set([...tags, ...dataTags]));
+    if (tags.length) {
+      svc.tags = tags.join(',');
+      const panelTag = tags.find(t => /^featured (service|project|product)$/i.test(t));
+      if (panelTag) svc.panel_tag = panelTag.toLowerCase();
+    }
+    services.push(svc);
+  });
+  return services;
+}
+
+function parseProjects($, base) {
+  const norm = (t) => (t || '').replace(/\s+/g, ' ').trim();
+  const projects = [];
+  $('.project').each((_, el) => {
+    const $p = $(el);
+    const proj = {};
+    const img = $p.find('img').attr('src');
+    if (img) proj.image_url = resolveUrl(img, base);
+    const title = norm($p.find('.title, h3, h2').first().text());
+    if (title) proj.title = title;
+    const href = $p.find('a').attr('href');
+    if (href) proj.cta_link = resolveUrl(href, base);
+    projects.push(proj);
+  });
+  return projects;
+}
+
 async function fetchTextWithGuards(url, { timeoutMs = 8000, byteLimit = 512_000 } = {}) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
@@ -224,6 +288,9 @@ async function parse(html, pageUrl) {
   const uniqueEmails  = Array.from(new Set(emails));
   const uniquePhones  = Array.from(new Set(phones));
 
+  const service_panels = parseServicePanels($, baseForResolve);
+  const projects = parseProjects($, baseForResolve);
+
   return {
     url: pageUrl,
     title,
@@ -236,6 +303,8 @@ async function parse(html, pageUrl) {
     text_blocks,
     social: uniqueSocials,
     contacts: { emails: uniqueEmails, phones: uniquePhones },
+    service_panels,
+    projects,
   };
 }
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -51,4 +51,32 @@ function pickBest(candidates = {}, targetKey = '', { min = 0.68 } = {}) {
   return { value, confidence: baseConf * bestScore, matched: bestKey };
 }
 
-module.exports = { similar, pickBest };
+function resolveServicePanels(src = {}) {
+  const services = Array.isArray(src.service_panels) ? [...src.service_panels] : [];
+  const gallery = Array.isArray(src.projects) ? src.projects : [];
+  let gi = 0;
+  while (services.length < 3 && gi < gallery.length) {
+    const g = gallery[gi++];
+    services.push({
+      title: g.title,
+      image_url: g.image_url,
+      cta_label: g.cta_label || g.title || null,
+      cta_link: g.cta_link,
+      panel_tag: 'featured project',
+      tags: 'featured project',
+    });
+  }
+  const fields = {};
+  for (let i = 0; i < Math.min(3, services.length); i++) {
+    const svc = services[i];
+    const idx = i + 1;
+    for (const [key, val] of Object.entries(svc)) {
+      if (val !== undefined && val !== null && val !== '') {
+        fields[`service_${idx}_${key}`] = val;
+      }
+    }
+  }
+  return fields;
+}
+
+module.exports = { similar, pickBest, resolveServicePanels };

--- a/test/fixtures/service-panels-1.html
+++ b/test/fixtures/service-panels-1.html
@@ -1,0 +1,20 @@
+<html><body>
+<div class="service-panel" data-tags="featured service">
+  <img src="/svc1.jpg">
+  <div class="price">$100</div>
+  <div class="price-note">per service</div>
+  <a class="cta" href="/buy1">Order</a>
+  <div class="delivery-modes">Onsite, Remote</div>
+  <ul class="inclusions"><li>A</li><li>B</li><li>C</li></ul>
+  <video src="/vid1.mp4"></video>
+  <ul class="tags"><li>tag1</li></ul>
+</div>
+<div class="project">
+  <img src="/proj1.jpg">
+  <h3>Project One</h3>
+</div>
+<div class="project">
+  <img src="/proj2.jpg">
+  <h3>Project Two</h3>
+</div>
+</body></html>

--- a/test/fixtures/service-panels-2.html
+++ b/test/fixtures/service-panels-2.html
@@ -1,0 +1,22 @@
+<html><body>
+<div class="service-panel" data-tags="featured service">
+  <img src="/svc1.jpg">
+  <div class="price">$100</div>
+  <div class="price-note">note1</div>
+  <a class="cta" href="/buy1">Order</a>
+  <div class="delivery-modes">Onsite</div>
+  <ul class="inclusions"><li>A</li><li>B</li></ul>
+</div>
+<div class="service-panel" data-tags="featured service">
+  <img src="/svc2.jpg">
+  <div class="price">$200</div>
+  <div class="price-note">note2</div>
+  <a class="cta" href="/buy2">Order2</a>
+  <div class="delivery-modes">Remote</div>
+  <ul class="inclusions"><li>D</li><li>E</li><li>F</li></ul>
+</div>
+<div class="project">
+  <img src="/proj1.jpg">
+  <h3>Project One</h3>
+</div>
+</body></html>

--- a/test/fixtures/service-panels-3.html
+++ b/test/fixtures/service-panels-3.html
@@ -1,0 +1,26 @@
+<html><body>
+<div class="service-panel" data-tags="featured service">
+  <img src="/svc1.jpg">
+  <div class="price">$100</div>
+  <div class="price-note">note1</div>
+  <a class="cta" href="/buy1">Order</a>
+  <div class="delivery-modes">Onsite</div>
+  <ul class="inclusions"><li>A</li><li>B</li><li>C</li></ul>
+</div>
+<div class="service-panel" data-tags="featured service">
+  <img src="/svc2.jpg">
+  <div class="price">$200</div>
+  <div class="price-note">note2</div>
+  <a class="cta" href="/buy2">Order2</a>
+  <div class="delivery-modes">Remote</div>
+  <ul class="inclusions"><li>D</li><li>E</li><li>F</li></ul>
+</div>
+<div class="service-panel" data-tags="featured product">
+  <img src="/svc3.jpg">
+  <div class="price">$300</div>
+  <div class="price-note">note3</div>
+  <a class="cta" href="/buy3">Order3</a>
+  <div class="delivery-modes">Online</div>
+  <ul class="inclusions"><li>G</li><li>H</li><li>I</li></ul>
+</div>
+</body></html>

--- a/test/service-panels.test.js
+++ b/test/service-panels.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { parse } = require('../lib/parse');
+const { resolveServicePanels } = require('../lib/resolve');
+
+function load(name) {
+  return fs.readFileSync(path.join(__dirname, 'fixtures', name), 'utf8');
+}
+
+test('auto-fill from gallery when 1 panel', async () => {
+  const html = load('service-panels-1.html');
+  const page = await parse(html, 'http://example.com');
+  const fields = resolveServicePanels(page);
+  assert.equal(fields.service_1_price, '$100');
+  assert.equal(fields.service_1_inclusion_3, 'C');
+  assert.equal(fields.service_1_cta_link, 'http://example.com/buy1');
+  assert.equal(fields.service_2_panel_tag, 'featured project');
+  assert.equal(fields.service_3_panel_tag, 'featured project');
+});
+
+test('auto-fill adds project when 2 panels present', async () => {
+  const html = load('service-panels-2.html');
+  const page = await parse(html, 'http://example.com');
+  const fields = resolveServicePanels(page);
+  assert.equal(fields.service_2_price, '$200');
+  assert.equal(fields.service_3_panel_tag, 'featured project');
+});
+
+test('no auto-fill needed for 3 panels', async () => {
+  const html = load('service-panels-3.html');
+  const page = await parse(html, 'http://example.com');
+  const fields = resolveServicePanels(page);
+  assert.equal(fields.service_3_price, '$300');
+  assert.equal(fields.service_3_panel_tag, 'featured product');
+});


### PR DESCRIPTION
## Summary
- parse service panels, projects and return structured fields
- auto-fill missing service panels from gallery/project content
- validate price, inclusion, tag and panel tag values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aafd1b26b8832a82e1a82dbb1f6e2a