### PR TITLE
Fix parser and resolver exports for test suite

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -400,7 +400,8 @@ async function parse(html, pageUrl) {
         source_url: source_url || null,
         job_type: job_type || null,
       });
-
+    }
+  });
 
   const service_panels = parseServicePanels($, baseForResolve);
   const projects = parseProjects($, baseForResolve);

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -85,9 +85,6 @@ function deriveFields(fields = {}, { tradecard_url } = {}) {
   }
 }
 
-module.exports = { similar, pickBest, deriveFields };
-
-
 function deriveSourceLabel(url = '') {
   if (!url) return undefined;
   try {
@@ -127,8 +124,6 @@ function resolveTestimonial(site = [], gmb = []) {
   return pick(site) || pick(gmb) || {};
 }
 
-module.exports = { similar, pickBest, resolveTestimonial, deriveSourceLabel };
-
 function resolveServicePanels(src = {}) {
   const services = Array.isArray(src.service_panels) ? [...src.service_panels] : [];
   const gallery = Array.isArray(src.projects) ? src.projects : [];
@@ -156,8 +151,6 @@ function resolveServicePanels(src = {}) {
   }
   return fields;
 }
-
-module.exports = { similar, pickBest, resolveServicePanels };
 
 function cleanSocialUrl(url = '', platform = '') {
   try {
@@ -208,7 +201,6 @@ function resolveSocialLinks(parsed = [], gmb_lookup = {}) {
   return out;
 }
 
-module.exports = { similar, pickBest, resolveSocialLinks };
 function resolveIdentity(parsed = {}) {
   const out = {};
 
@@ -259,5 +251,15 @@ function resolveIdentity(parsed = {}) {
   return out;
 }
 
-module.exports = { similar, pickBest, resolveIdentity };
+module.exports = {
+  similar,
+  pickBest,
+  deriveFields,
+  deriveSourceLabel,
+  resolveTestimonial,
+  resolveServicePanels,
+  cleanSocialUrl,
+  resolveSocialLinks,
+  resolveIdentity,
+};
 

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -35,6 +35,7 @@ test('parse captures videos, contact forms, awards and theme colors', async () =
   assert.deepEqual(page.contact_form_links, ['https://example.com/contact']);
   assert.ok(page.profile_videos.includes('https://youtube.com/watch?v=abc'));
   assert.equal(page.awards[0].text, 'Best Award 2023');
+});
 
 test('parse extracts on-site testimonials', async () => {
   const html = fs.readFileSync(path.join(__dirname, 'fixtures/testimonial.html'), 'utf8');


### PR DESCRIPTION
## Summary
- repair parse.js by joining CSS asset fetch config and closing testimonial parsing block
- consolidate resolve.js exports so helper functions are accessible
- close open block in parse tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab884926c0832abcb90f6bc209f360