### PR TITLE
Expand identity field coverage

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -212,19 +212,26 @@ function resolveIdentity(parsed = {}) {
     'identity_owner_name',
     'identity_role_title',
     'identity_headshot_url',
+    'identity_logo_url',
     'identity_suburb',
     'identity_state',
     'identity_abn',
     'identity_insured',
+    'identity_business_type',
+    'identity_business_name',
+    'identity_location_label',
     'identity_address',
     'identity_email',
     'identity_phone',
+    'identity_website',
     'identity_website_url',
     'identity_uri_phone',
     'identity_uri_email',
     'identity_uri_sms',
     'identity_uri_whatsapp',
-    'identity_address_uri'
+    'identity_address_uri',
+    'identity_display_name',
+    'identity_verified'
   ].forEach(copy);
 
   if (Array.isArray(parsed.identity_services)) {
@@ -246,6 +253,18 @@ function resolveIdentity(parsed = {}) {
   if (!out.identity_address_uri && parsed.identity_address) {
     out.identity_address_uri =
       `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(parsed.identity_address)}`;
+  }
+
+  if (!out.identity_display_name) {
+    if (out.identity_owner_name) {
+      out.identity_display_name = out.identity_owner_name;
+    } else if (out.identity_business_name) {
+      out.identity_display_name = out.identity_business_name;
+    }
+  }
+
+  if (!out.identity_verified && out.identity_abn && out.identity_owner_name && out.identity_phone) {
+    out.identity_verified = 'true';
   }
 
   return out;

--- a/scripts/audit-intent.js
+++ b/scripts/audit-intent.js
@@ -25,6 +25,7 @@ Object.keys(doc).forEach((key) => {
 // Build ACF schema allow set
 const identityFields = [
   'business_name',
+  'business_type',
   'website_url',
   'email',
   'phone',
@@ -36,9 +37,12 @@ const identityFields = [
   'owner_name',
   'role_title',
   'headshot_url',
+  'insured',
   'website',
   'location_label',
   'services',
+  'display_name',
+  'verified',
   'uri_phone',
   'uri_email',
   'uri_sms',
@@ -70,7 +74,9 @@ const trustFields = [
   'review_button_link',
   'profile_video_url',
   'contact_form',
-  'vcf_url'
+  'vcf_url',
+  'award',
+  'award_link'
 ];
 const themeFields = ['primary_color', 'accent_color'];
 const serviceFields = [

--- a/test/identity.resolve.test.js
+++ b/test/identity.resolve.test.js
@@ -8,6 +8,12 @@ const { resolveIdentity } = require('../lib/resolve');
 test('raw profile resolves into full identity block', async () => {
   const html = fs.readFileSync(path.join(__dirname, 'fixtures/profile.html'), 'utf8');
   const parsed = await parse(html, 'http://biz.example.com');
+  Object.assign(parsed, {
+    identity_logo_url: 'http://biz.example.com/logo.png',
+    identity_business_type: 'Plumber',
+    identity_location_label: 'Sydney NSW',
+    identity_business_name: 'Jane Doe Plumbing'
+  });
   const identity = resolveIdentity(parsed);
 
   assert.equal(identity.identity_owner_name, 'Jane Doe');
@@ -17,6 +23,10 @@ test('raw profile resolves into full identity block', async () => {
   assert.equal(identity.identity_state, 'NSW');
   assert.equal(identity.identity_abn, '12345678901');
   assert.equal(identity.identity_insured, 'Fully insured for all work');
+  assert.equal(identity.identity_logo_url, 'http://biz.example.com/logo.png');
+  assert.equal(identity.identity_business_type, 'Plumber');
+  assert.equal(identity.identity_location_label, 'Sydney NSW');
+  assert.equal(identity.identity_business_name, 'Jane Doe Plumbing');
   assert.equal(identity.identity_address, '123 Street, Suburb, NSW 2000');
   assert.equal(identity.identity_email, 'jane@example.com');
   assert.equal(identity.identity_phone, '+610212345678');
@@ -31,4 +41,6 @@ test('raw profile resolves into full identity block', async () => {
   assert.equal(identity.identity_uri_phone, 'tel:+610212345678');
   assert.equal(identity.identity_uri_sms, 'sms:+610212345678');
   assert.equal(identity.identity_uri_whatsapp, 'https://wa.me/610212345678');
+  assert.equal(identity.identity_display_name, 'Jane Doe');
+  assert.equal(identity.identity_verified, 'true');
 });


### PR DESCRIPTION
## Summary
- support additional identity fields and derive display name and verification
- audit intent script covers all identity and trust fields
- test identity resolver handles new fields

## Testing
- `npm test`
- `npm run audit:intent` *(fails: YAMLParseError: Implicit map keys need to be followed by map values at line 152, column 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8cfab9f8832ab369e7d71f410ed9