### PR TITLE
Enrich tradecards via inference before intent resolution

### DIFF
--- a/test/build.push.llm.test.js
+++ b/test/build.push.llm.test.js
@@ -26,7 +26,7 @@ test('build route returns 422 on thin payload when push=1', async () => {
     }
   });
 
-  const req = { query: { url: 'http://site.test', push: '1' } };
+  const req = { query: { url: 'http://site.test', push: '1', resolve: 'none' } };
   const res = { status(c) { this.statusCode = c; return this; }, json(o) { this.body = o; } };
   await handler(req, res);
   restore();
@@ -55,7 +55,7 @@ test('build route returns 200 on thin payload when push=0', async () => {
     }
   });
 
-  const req = { query: { url: 'http://site.test', push: '0' } };
+  const req = { query: { url: 'http://site.test', push: '0', resolve: 'none' } };
   const res = { status(c) { this.statusCode = c; return this; }, json(o) { this.body = o; } };
   await handler(req, res);
   restore();

--- a/test/build_route.test.js
+++ b/test/build_route.test.js
@@ -24,6 +24,23 @@ test('build route performs crawl, intent resolve, push', async () => {
             {
               message: {
                 content: JSON.stringify({
+                  business: { description: 'Inferred Desc' },
+                  services: { list: ['Inferred Service'] },
+                  service_areas: ['Area1'],
+                  brand: { tone: 'Friendly' },
+                  testimonials: [{ quote: 'Great', reviewer: 'Ann' }]
+                })
+              }
+            }
+          ]
+        }
+      },
+      {
+        json: {
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
                   identity_business_name: 'Biz',
                   identity_website_url: 'http://site.test',
                   identity_email: 'a@b.com',
@@ -56,6 +73,7 @@ test('build route performs crawl, intent resolve, push', async () => {
   assert.equal(res.statusCode, 200);
   assert.ok(res.body.wordpress.ok);
   assert.ok(res.body.debug.trace.find(t => t.stage === 'crawl'));
+  assert.ok(res.body.debug.trace.find(t => t.stage === 'infer'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'intent_input'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'det_resolve'));
   assert.ok(res.body.debug.trace.find(t => t.stage === 'llm_resolve'));
@@ -68,4 +86,6 @@ test('build route performs crawl, intent resolve, push', async () => {
   assert.equal(acf_step.response.status, 200);
   assert.ok(Array.isArray(res.body.wordpress.details.acf_keys));
   assert.ok(res.body.wordpress.details.acf_keys.length >= 1);
+  assert.equal(res.body.tradecard.business.description.value, 'Inferred Desc');
+  assert.deepEqual(res.body.tradecard.services.list.value, ['Inferred Service']);
 });


### PR DESCRIPTION
## Summary
- run inferTradecard during build to prefill business description, services, service areas, brand tone, and testimonials
- merge inferred data into tradecard and record inference stage in trace
- adjust tests to validate inference enrichment and accommodate inference-only runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab96e0a9c4832a902c9a2bf3c48c60