### PR TITLE
feat: expand LLM raw pruning

### DIFF
--- a/lib/llm_resolver.js
+++ b/lib/llm_resolver.js
@@ -32,6 +32,44 @@ function pruneRaw(raw = {}) {
       }
     });
   }
+  if (Array.isArray(raw.text_blocks) && raw.text_blocks.length) {
+    out.text_blocks = raw.text_blocks
+      .slice(0, 50)
+      .map((t) => String(t).slice(0, 200));
+  }
+  if (Array.isArray(raw.profile_videos) && raw.profile_videos.length) {
+    out.profile_videos = raw.profile_videos
+      .slice(0, 5)
+      .map((v) => String(v).slice(0, 200));
+  }
+  if (Array.isArray(raw.contact_form_links) && raw.contact_form_links.length) {
+    out.contact_form_links = raw.contact_form_links
+      .slice(0, 5)
+      .map((v) => String(v).slice(0, 200));
+  }
+  if (Array.isArray(raw.awards) && raw.awards.length) {
+    out.awards = raw.awards.slice(0, 10).map((a) => ({
+      text: String(a.text || '').slice(0, 200),
+      href: String(a.href || '').slice(0, 200)
+    }));
+  }
+  if (Array.isArray(raw.social) && raw.social.length) {
+    out.social = raw.social.slice(0, 10).map((s) => ({
+      platform: s.platform || '',
+      url: s.url || ''
+    }));
+  }
+  if (raw.contacts && typeof raw.contacts === 'object') {
+    const { emails, phones } = raw.contacts;
+    const contacts = {};
+    if (Array.isArray(emails) && emails.length) {
+      contacts.emails = emails.slice(0, 10).map((e) => String(e).slice(0, 200));
+    }
+    if (Array.isArray(phones) && phones.length) {
+      contacts.phones = phones.slice(0, 10).map((p) => String(p).slice(0, 100));
+    }
+    if (Object.keys(contacts).length) out.contacts = contacts;
+  }
   return out;
 }
 

--- a/test/llm_resolver.test.js
+++ b/test/llm_resolver.test.js
@@ -61,3 +61,37 @@ test('resolveWithLLM targets missing keys', async () => {
   restore();
   assert.deepEqual(user.targets, ['service_2_title']);
 });
+
+test('resolveWithLLM includes extra raw fields in pruned payload', async () => {
+  resetEnv({ OPENAI_API_KEY: 'k' });
+  let body;
+  const raw = {
+    text_blocks: ['a', 'b'],
+    profile_videos: ['v1'],
+    contact_form_links: ['f1'],
+    awards: [{ text: 'Best', href: 'https://a.example' }],
+    social: [{ platform: 'facebook', url: 'https://fb.com/x' }],
+    contacts: { emails: ['e@x.com'], phones: ['123'] }
+  };
+  const restore = mockFetch({
+    'https://api.openai.com/v1/chat/completions': (url, opts) => {
+      body = JSON.parse(opts.body);
+      return { json: { choices: [{ message: { content: '{}' } }] } };
+    }
+  });
+
+  await resolveWithLLM({ raw, allowKeys: new Set(['some']) });
+  restore();
+  const pruned = JSON.parse(body.messages[1].content).raw_pruned;
+  assert.deepEqual(pruned.text_blocks, ['a', 'b']);
+  assert.deepEqual(pruned.profile_videos, ['v1']);
+  assert.deepEqual(pruned.contact_form_links, ['f1']);
+  assert.deepEqual(pruned.awards, [{ text: 'Best', href: 'https://a.example' }]);
+  assert.deepEqual(pruned.social, [
+    { platform: 'facebook', url: 'https://fb.com/x' }
+  ]);
+  assert.deepEqual(pruned.contacts, {
+    emails: ['e@x.com'],
+    phones: ['123']
+  });
+});


### PR DESCRIPTION
## Summary
- include text blocks, media, awards, socials, and contact info in LLM raw pruning
- test that pruned payload exposes new fields to LLM

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab96e36394832a8a0dbc6d95a36438