### PR TITLE
feat: include tradecard context for LLM

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -32,7 +32,14 @@ async function applyIntent(tradecard, { raw, resolve = 'llm' } = {}) {
   const min = Number(process.env.MIN_ACF_KEYS) || allow.size;
   if (resolve === 'llm' && remaining.size && sent.size < min) {
     const { resolveWithLLM } = require('./llm_resolver');
-    const llm = await resolveWithLLM({ raw: raw || {}, allowKeys: remaining, hints: fields });
+    const context = {
+      business_name: tradecard?.business?.name,
+      contacts: tradecard?.contacts,
+      social: tradecard?.social,
+      services: tradecard?.services?.list,
+      service_areas: tradecard?.service_areas
+    };
+    const llm = await resolveWithLLM({ raw: raw || {}, allowKeys: remaining, hints: fields, context });
     for (const [k, v] of Object.entries(llm.fields || {})) put(k, v);
     audit.push(...(llm.audit || []));
     trace.push({

--- a/lib/llm_resolver.js
+++ b/lib/llm_resolver.js
@@ -35,7 +35,7 @@ function pruneRaw(raw = {}) {
   return out;
 }
 
-async function resolveWithLLM({ raw = {}, allowKeys = new Set(), hints = {} } = {}) {
+async function resolveWithLLM({ raw = {}, allowKeys = new Set(), hints = {}, context = {} } = {}) {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey || !(allowKeys instanceof Set) || allowKeys.size === 0) {
     return { fields: {}, audit: [] };
@@ -44,6 +44,7 @@ async function resolveWithLLM({ raw = {}, allowKeys = new Set(), hints = {} } = 
   const user = {
     allowKeys: Array.from(allowKeys),
     hints,
+    context,
     raw_pruned: pruneRaw(raw),
     targets: Array.from(allowKeys).filter((k) => !hints[k])
   };

--- a/test/build.push.llm.test.js
+++ b/test/build.push.llm.test.js
@@ -18,11 +18,11 @@ test('build route returns 422 on thin payload when push=1', async () => {
   }];
 
   resetEnv({ OPENAI_API_KEY: 'k' });
+  let body;
   const restore = mockFetch({
-    'https://api.openai.com/v1/chat/completions': {
-      json: {
-        choices: [ { message: { content: '{}' } } ]
-      }
+    'https://api.openai.com/v1/chat/completions': (url, opts) => {
+      body = JSON.parse(opts.body);
+      return { json: { choices: [ { message: { content: '{}' } } ] } };
     }
   });
 
@@ -33,6 +33,9 @@ test('build route returns 422 on thin payload when push=1', async () => {
 
   assert.equal(res.statusCode, 422);
   assert.equal(res.body.reason, 'thin_payload');
+  const user = JSON.parse(body.messages[1].content);
+  assert.equal(user.context.business_name, 'site.test');
+  assert.equal(user.context.contacts.website, 'http://site.test');
 });
 
 test('build route returns 200 on thin payload when push=0', async () => {

--- a/test/llm_resolver.test.js
+++ b/test/llm_resolver.test.js
@@ -61,3 +61,24 @@ test('resolveWithLLM targets missing keys', async () => {
   restore();
   assert.deepEqual(user.targets, ['service_2_title']);
 });
+
+test('resolveWithLLM includes context in payload', async () => {
+  resetEnv({ OPENAI_API_KEY: 'k' });
+  let body;
+  const restore = mockFetch({
+    'https://api.openai.com/v1/chat/completions': (url, opts) => {
+      body = JSON.parse(opts.body);
+      return { json: { choices: [{ message: { content: '{}' } }] } };
+    }
+  });
+
+  await resolveWithLLM({
+    raw: {},
+    hints: {},
+    context: { business_name: 'Ctx Biz' },
+    allowKeys: new Set(['identity_business_name'])
+  });
+  const user = JSON.parse(body.messages[1].content);
+  restore();
+  assert.equal(user.context.business_name, 'Ctx Biz');
+});


### PR DESCRIPTION
## Summary
- allow resolveWithLLM to accept context so the LLM can cross reference tradecard details
- send business name, contacts, services, and more from intent when invoking resolveWithLLM
- add tests covering context propagation through resolver and build handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab96e4a7a0832a924d9583f76444e2