### PR TITLE
Track unresolved intent fields and document trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Tradecard API
+
+## Intent resolution trace
+
+The `applyIntent` helper returns an array of trace objects describing how fields were populated.
+These traces now include an `unresolved` stage which lists any allowed keys that remain
+empty after deterministic, LLM, and derived resolutions:
+
+```js
+{
+  stage: 'unresolved',
+  remaining: ['field_a', 'field_b']
+}
+```
+
+This makes it easier for API clients to debug missing data.

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -45,11 +45,15 @@ async function applyIntent(tradecard, { raw, resolve = 'llm' } = {}) {
   deriveFields(fields, { tradecard_url: tradecard?.tradecard_url || tradecard?.url });
   for (const k of Object.keys(fields)) sent.add(k);
 
+  const unresolved = Array.from(allow).filter((k) => !fields[k]);
+
   trace.push({
     stage: 'intent_coverage',
     after: sent.size,
     sample_sent: Array.from(sent).slice(0, 10)
   });
+
+  trace.push({ stage: 'unresolved', remaining: unresolved });
 
   return { fields, sent_keys: Array.from(sent), audit, trace };
 }


### PR DESCRIPTION
## Summary
- record missing allowed keys in an `unresolved` trace entry after intent resolution
- document `unresolved` trace entries in the README for easier debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab96e633a8832a8b44e015d693aa67