### PR TITLE
Use structured JSON payload for inference requests

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -57,13 +57,27 @@ async function inferTradecard(tradecard = {}) {
   const summary = {
     name: tradecard?.business?.name,
     headings: (tradecard?.content?.headings || [])
-      .map(h => h.text)
+      .map((h) => h.text)
       .slice(0, 25),
     contacts: {
       emails: tradecard?.contacts?.emails || [],
       phones: tradecard?.contacts?.phones || []
     },
     images: (tradecard?.assets?.images || []).slice(0, 3)
+  };
+
+  const website = tradecard?.contacts?.website;
+  let domain;
+  try {
+    domain = new URL(website).hostname.replace(/^www\./, '');
+  } catch {}
+
+  const userPayload = {
+    context: {
+      business_name: domain || tradecard?.business?.name,
+      contacts: { website }
+    },
+    summary
   };
 
   const controller = new AbortController();
@@ -81,9 +95,10 @@ async function inferTradecard(tradecard = {}) {
         messages: [
           {
             role: 'system',
-            content: 'Output ONLY JSON where each field is {"value":...,"confidence":0-1}. Schema: {"business":{"description":{}},"services":{"list":{}},"service_areas":{},"brand":{"tone":{}},"testimonials":{}}. Omit unknowns.'
+            content:
+              'Output ONLY JSON where each field is {"value":...,"confidence":0-1}. Schema: {"business":{"description":{}},"services":{"list":{}},"service_areas":{},"brand":{"tone":{}},"testimonials":{}}. Omit unknowns.'
           },
-          { role: 'user', content: `Fill missing fields for: ${JSON.stringify(summary)}` }
+          { role: 'user', content: JSON.stringify(userPayload) }
         ],
         temperature: 0.2,
         max_tokens: 600,

--- a/test/llm_resolver.test.js
+++ b/test/llm_resolver.test.js
@@ -89,11 +89,10 @@ test('resolveWithLLM includes extra raw fields in pruned payload', async () => {
     allowKeys: new Set(['identity_business_name'])
   });
   const user = JSON.parse(body.messages[1].content);
-  restore();
   assert.equal(user.context.business_name, 'Ctx Biz');
   await resolveWithLLM({ raw, allowKeys: new Set(['some']) });
-  restore();
   const pruned = JSON.parse(body.messages[1].content).raw_pruned;
+  restore();
   assert.deepEqual(pruned.text_blocks, ['a', 'b']);
   assert.deepEqual(pruned.profile_videos, ['v1']);
   assert.deepEqual(pruned.contact_form_links, ['f1']);


### PR DESCRIPTION
## Summary
- send context-rich JSON when invoking OpenAI in `inferTradecard`
- keep mock fetch active in LLM resolver test to validate pruned raw payload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab99b31b90832a9656f15b9865ac53