### PR TITLE
Filter ACF payload to ACF contract

### DIFF
--- a/lib/acfContract.ts
+++ b/lib/acfContract.ts
@@ -1,0 +1,27 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
+
+/** @typedef {{allow:string[], aliases:Record<string,string>}} Contract */
+let cache;
+function load() {
+  if (!cache) {
+    const file = fs.readFileSync(path.join(__dirname, '..', 'config', 'acf_field.yaml'), 'utf8');
+    const data = YAML.parse(file) || {};
+    cache = { allow: data.allow || [], aliases: data.aliases || {} };
+  }
+  return cache;
+}
+
+function getAllowKeys() {
+  return load().allow;
+}
+function hasACFKey(k) {
+  const c = load();
+  return c.allow.includes(c.aliases[k] || k);
+}
+function getAliases() {
+  return load().aliases;
+}
+
+module.exports = { getAllowKeys, hasACFKey, getAliases };


### PR DESCRIPTION
## Summary
- add `lib/acfContract.ts` to load allow-listed fields and aliases from `config/acf_field.yaml`
- remap and filter ACF payload in `api/build.js` to contract, convert nulls to "", and trace sent keys

## Testing
- `npm test`
- `curl -s "$BASE/api/build?url=$TARGET&push=1&debug=1" | jq '.debug.trace[]?|select(.step=="acf_sync")|.sent_keys'` *(fails: no output, missing BASE/TARGET)*

------
https://chatgpt.com/codex/tasks/task_e_68abea541f08832aa97c159b72b328b6