### PR TITLE
feat: add coverage metric and publishing gates

### DIFF
--- a/lib/coverage.ts
+++ b/lib/coverage.ts
@@ -1,0 +1,11 @@
+function computeCoverage(clean = {}, allow = new Set()) {
+  const total = allow.size;
+  if (!total) return 0;
+  let count = 0;
+  for (const key of allow) {
+    if (clean[key] !== undefined && clean[key] !== null) count++;
+  }
+  return count / total;
+}
+
+module.exports = { computeCoverage };

--- a/lib/gates.ts
+++ b/lib/gates.ts
@@ -1,0 +1,26 @@
+const REQUIRED_ACF_KEYS = [
+  'identity_business_name',
+  'identity_owner_name',
+  'identity_phone',
+  'identity_email',
+  'identity_state',
+  'identity_role_title',
+  'identity_business_type',
+  'identity_website',
+  'identity_location_label',
+  'service_1_title'
+];
+
+function resolveGate({ coverage, requiredPresent, threshold }) {
+  if (!requiredPresent) return { pass: false, reason: 'missing_required' };
+  if (coverage < threshold) return { pass: false, reason: 'insufficient_coverage' };
+  return { pass: true };
+}
+
+function publishGate({ resolvePass, requiredMissing }) {
+  if (!resolvePass) return { pass: false, reason: 'resolve_failed' };
+  if (requiredMissing && requiredMissing.length) return { pass: false, reason: 'missing_required' };
+  return { pass: true };
+}
+
+module.exports = { resolveGate, publishGate, REQUIRED_ACF_KEYS };


### PR DESCRIPTION
## Summary
- add coverage computation for ACF fields
- gate resolve and publish steps using coverage and required ACF keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abedd00278832a9a2fd93d652f6d36