### PR TITLE
test: verify coverage gate threshold

### DIFF
--- a/test/coverage.threshold.test.js
+++ b/test/coverage.threshold.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { resolveGate } = require('../lib/gates.ts');
+
+test('resolveGate fails when coverage is below threshold', () => {
+  const out = resolveGate({ coverage: 0.49, requiredPresent: true, threshold: 0.5 });
+  assert.deepEqual(out, { pass: false, reason: 'insufficient_coverage' });
+});
+
+test('resolveGate passes when coverage meets threshold', () => {
+  const out = resolveGate({ coverage: 0.51, requiredPresent: true, threshold: 0.5 });
+  assert.deepEqual(out, { pass: true });
+});


### PR DESCRIPTION
## Summary
- add tests ensuring resolveGate fails below threshold and passes above

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac100bd978832aa1462ce9ca2a0eee