### PR TITLE
Augment intent fields with resolved identity and social links

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -3,6 +3,7 @@ const imap = require('./intent_map');
 const { runExecutor } = require('./executor');
 const llm = require('./llm_resolver');
 const { completeness } = require('./completeness');
+const { resolveIdentity, resolveSocialLinks, deriveFields } = require('./resolve');
 
 function normalizePhone(p = '') {
   let digits = String(p).replace(/[^0-9]/g, '');
@@ -100,6 +101,12 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {} } = 
   const allowSet = getAllowKeys();
   const map = imap.loadIntentMap();
   const { fields, audit } = await runExecutor({ map, allowSet, raw, tradecard, llm, helpers });
+
+  const identity = resolveIdentity(raw);
+  const social = resolveSocialLinks(raw.social, raw.gmb_lookup || {});
+  deriveFields(fields, { tradecard_url: tradecard?.slug });
+  Object.assign(fields, identity, social);
+
   const trace = [];
   trace.push({ stage: 'rule_apply', audit });
   trace.push({ stage: 'intent_coverage', before: Object.keys(map).length, after: Object.keys(fields).length, sample_sent: Object.keys(fields).slice(0, 10) });

--- a/test/intent.derive.test.js
+++ b/test/intent.derive.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { applyIntent } = require('../lib/intent');
+
+test('applyIntent merges derived identity, social, and trust fields', async () => {
+  const tradecard = { slug: 'https://tradecard.au/acme' };
+  const raw = {
+    identity_abn: '123',
+    identity_owner_name: 'John Doe',
+    identity_phone: '+61123456789',
+    identity_address: '1 Main St',
+    social: [
+      { platform: 'facebook', url: 'http://facebook.com/Acme?fbclid=1' }
+    ],
+    gmb_lookup: {
+      social_links_twitter: 'https://twitter.com/Acme?utm_source=1'
+    }
+  };
+  const { fields } = await applyIntent(tradecard, { raw });
+  assert.equal(fields.identity_display_name, 'John Doe');
+  assert.equal(fields.identity_verified, 'true');
+  assert.equal(fields.identity_address_uri, 'https://www.google.com/maps/search/?api=1&query=1%20Main%20St');
+  assert.equal(fields.social_links_facebook, 'https://facebook.com/acme');
+  assert.equal(fields.social_links_twitter, 'https://twitter.com/acme');
+  assert.equal(fields.trust_qr_text, 'https://tradecard.au/acme');
+  assert.equal(fields.trust_vcf_url, 'https://contact.tradecard.au/acme.vcf');
+});


### PR DESCRIPTION
## Summary
- populate derived identity and social link fields in applyIntent
- derive trust QR text and VCF URL from tradecard slug
- add test covering merged identity, social, and trust fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac17b26dfc832a9916254f25eab48e