### PR TITLE
feat: enrich LLM payload and batch field resolution

### DIFF
--- a/lib/llm_resolver.js
+++ b/lib/llm_resolver.js
@@ -27,19 +27,59 @@ async function callOpenAI(payload) {
   }
 }
 
-module.exports.resolveField = async function resolveField(key, rule = {}, { raw = {}, tradecard = {} } = {}) {
+const batchCache = new Map();
+
+module.exports.resolveField = async function resolveField(
+  key,
+  rule = {},
+  { raw = {}, tradecard = {}, fields = {} } = {}
+) {
+  const llmRule = rule.llm || {};
+  const batchKey = llmRule.batch ? llmRule.prompt || key : null;
+  if (batchKey && batchCache.has(batchKey)) {
+    const cached = batchCache.get(batchKey);
+    return cached[key] || '';
+  }
+
   const payload = {
     links: (raw.anchors || []).slice(0, 50).map((a) => ({ href: a.href || '', text: a.text || '' })),
     headings: (raw.headings || []).slice(0, 25).map((h) => h.text || h),
     images: (raw.images || []).slice(0, 30).map((i) => ({ src: i.src || '', alt: i.alt || '' })),
+    text_blocks: (raw.text_blocks || [])
+      .slice(0, 100)
+      .map((t) => String(t).slice(0, 200)),
+    meta: raw.meta || {},
+    jsonld: raw.jsonld || [],
+    service_panels: Array.isArray(raw.service_panels)
+      ? raw.service_panels.slice(0, 10)
+      : [],
+    projects: Array.isArray(raw.projects) ? raw.projects.slice(0, 10) : [],
     hints: {
       name: tradecard?.business?.name || '',
       website: tradecard?.contacts?.website || ''
     },
-    instructions: rule?.llm?.prompt || ''
+    instructions: llmRule.prompt || ''
   };
-  let s = (await callOpenAI(payload)).trim();
-  const v = rule?.llm?.validate || {};
+
+  if (llmRule.batch) {
+    const keys = Array.isArray(llmRule.keys) ? llmRule.keys : [key];
+    payload.keys = keys;
+  }
+
+  let rawRes = (await callOpenAI(payload)).trim();
+  if (llmRule.batch) {
+    let obj;
+    try {
+      obj = JSON.parse(rawRes);
+    } catch {
+      obj = { [key]: rawRes };
+    }
+    batchCache.set(batchKey, obj);
+    rawRes = obj[key] || '';
+  }
+
+  let s = rawRes;
+  const v = llmRule.validate || {};
   if (s && v.regex) {
     const rx = new RegExp(v.regex.replace(/^\/|\/$/g, ''), 'i');
     if (!rx.test(s)) s = '';


### PR DESCRIPTION
## Summary
- Expand LLM payload with additional raw scrape context including text blocks, metadata, jsonld, service panels, and projects.
- Add basic batching capability with caching to reuse results for related fields in a single request.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac17b42560832a8897624be1bd044c