### PR TITLE
Fix detResolve syntax in intent helpers

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -104,16 +104,6 @@ const helpers = {
     }
     return out;
   },
-  detResolve(key, rule, { raw = {} }) {
-    if (raw && Object.prototype.hasOwnProperty.call(raw, key)) {
-      return raw[key];
-    }
-    if (key.startsWith('service_')) {
-      const svc = resolveServicePanels(raw);
-      return svc[key] || '';
-    }
-    return '';
-
   detResolve(key, rule, ctx) {
     const raw = ctx?.raw || {};
     let val;


### PR DESCRIPTION
## Summary
- remove duplicate `detResolve` definition causing syntax error
- ensure `detResolve` pulls values from raw data, service panels, or testimonials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3f6b8488832aafe3edc35e468e6f