### PR TITLE
feat: add full-frame resolve path

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -17,6 +17,7 @@ module.exports = async function handler(req, res) {
   const maxPages = Math.min(parseInt(req.query?.maxPages || '12', 10) || 12, 50);
   const maxDepth = Math.min(parseInt(req.query?.maxDepth || '2', 10) || 2, 5);
   const sameOriginOnly = (req.query?.sameOrigin ?? '1') !== '0';
+  const fullFrame = ['1', 'true', 1, true].includes(req.query.full_frame);
   const trace = [];
   const debug = { trace };
   const aliases = getAliases();
@@ -77,7 +78,7 @@ module.exports = async function handler(req, res) {
       }
     });
 
-    const intent = await applyIntent(result.tradecard, { raw });
+    const intent = await applyIntent(result.tradecard, { raw, fullFrame });
     if (Array.isArray(intent.trace)) debug.trace.push(...intent.trace);
 
     const map = loadMap();

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -11,6 +11,10 @@ const {
   resolveTestimonial,
   similar,
 } = require('./resolve');
+const { fullFramePropose } = require('./llmFullFrame');
+const { readYaml } = require('./config');
+
+const resolveConfig = readYaml('config/resolve.yaml');
 
 function fuzzyFindKey(obj = {}, target = '', minScore = 0.65) {
   let bestKey;
@@ -157,7 +161,22 @@ const helpers = {
   }
 };
 
-exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {} } = {}) {
+function passesValidation(val, rule = {}) {
+  let s = String(val || '').trim();
+  if (!s) return false;
+  const v = rule?.llm?.validate || {};
+  if (v.regex) {
+    const rx = new RegExp(v.regex.replace(/^\/|\/$/g, ''), 'i');
+    if (!rx.test(s)) return false;
+  }
+  if (v.url && !/^https?:\/\//i.test(s)) return false;
+  if (v.min_len && s.length < v.min_len) return false;
+  if (v.max_len && s.length > v.max_len) return false;
+  return true;
+}
+
+exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, fullFrame = false } = {}) {
+  const trace = [];
   const allowSet = getAllowKeys();
   const map = imap.loadIntentMap();
   const { fields, audit } = await runExecutor({ map, allowSet, raw, tradecard, llm, helpers });
@@ -167,8 +186,22 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {} } = 
   deriveFields(fields, { tradecard_url: tradecard?.slug });
   Object.assign(fields, identity, social);
 
-  const trace = [];
   trace.push({ stage: 'rule_apply', audit });
+
+  if (fullFrame) {
+    const { proposals, stats } = await fullFramePropose({ raw, intentMap: map, resolveConfig, allowKeys: Array.from(allowSet), fixture: tradecard?.slug });
+    const accepted = [];
+    const rejected = [];
+    for (const [k, v] of Object.entries(proposals || {})) {
+      if (!allowSet.has(k)) { rejected.push({ key: k, reason: 'non-allowlisted' }); continue; }
+      const rule = imap.ruleFor(map, k);
+      if (fields[k] && passesValidation(fields[k], rule)) { rejected.push({ key: k, reason: 'already_set' }); continue; }
+      if (passesValidation(v, rule)) { fields[k] = String(v); accepted.push(k); }
+      else { rejected.push({ key: k, reason: 'failed-validate' }); }
+    }
+    trace.push({ stage: 'llm_full_frame', proposed: stats.proposed_count, accepted, rejected, has_raw: !!raw, approx_bytes: stats.bytes_in, approx_tokens: stats.tokens_est });
+  }
+
   trace.push({ stage: 'intent_coverage', before: Object.keys(map).length, after: Object.keys(fields).length, sample_sent: Object.keys(fields).slice(0, 10) });
   trace.push({ stage: 'completeness', report: completeness(map, fields) });
   return { fields, sent_keys: Object.keys(fields), audit, trace };

--- a/lib/llmFullFrame.js
+++ b/lib/llmFullFrame.js
@@ -1,0 +1,88 @@
+"use strict";
+
+async function callLLM(payload) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return '{}';
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        temperature: 0,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: 'Extract data and return only valid JSON.' },
+          { role: 'user', content: JSON.stringify(payload) }
+        ]
+      })
+    });
+    const data = await res.json().catch(() => ({}));
+    return data?.choices?.[0]?.message?.content || '{}';
+  } catch {
+    return '{}';
+  }
+}
+
+function prepareRaw(raw = {}) {
+  const buckets = {
+    anchors: raw.anchors || [],
+    headings: raw.headings || [],
+    images: raw.images || [],
+    jsonld: raw.jsonld || [],
+    meta: raw.meta || {}
+  };
+  let out = buckets;
+  const MAX_BYTES = 12000;
+  let bytes = Buffer.byteLength(JSON.stringify(out));
+  if (bytes > MAX_BYTES) {
+    out = {
+      anchors: buckets.anchors.slice(0, 50),
+      headings: buckets.headings.slice(0, 50),
+      images: buckets.images.slice(0, 50),
+      jsonld: buckets.jsonld.slice(0, 20),
+      meta: Object.fromEntries(Object.entries(buckets.meta).slice(0, 20)),
+      counts: {
+        anchors: buckets.anchors.length,
+        headings: buckets.headings.length,
+        images: buckets.images.length,
+        jsonld: buckets.jsonld.length,
+        meta: Object.keys(buckets.meta).length
+      }
+    };
+    bytes = Buffer.byteLength(JSON.stringify(out));
+  }
+  return { raw: out, bytes };
+}
+
+async function fullFramePropose({ raw = {}, intentMap = {}, resolveConfig = {}, allowKeys = [], fixture = '' }) {
+  const { raw: safeRaw, bytes } = prepareRaw(raw);
+  const fieldIntent = {};
+  for (const k of allowKeys) if (intentMap[k]) fieldIntent[k] = intentMap[k];
+  const resolveCfg = {};
+  for (const k of allowKeys) if (resolveConfig[k]) resolveCfg[k] = resolveConfig[k];
+
+  const prompt = {
+    fixture,
+    ALLOW_KEYS: allowKeys,
+    RAW: safeRaw,
+    FIELD_INTENT: fieldIntent,
+    RESOLVE_CONFIG: resolveCfg,
+    INSTRUCTION: 'Return a flat JSON object of {key: value} for keys ∈ allowKeys only. No new keys. Prefer exact strings from RAW; synthesize only when necessary and validate shape (email/phone/url/len). Return empty string for unknown.'
+  };
+  const inputStr = JSON.stringify(prompt);
+  const tokens = Math.ceil(Buffer.byteLength(inputStr) / 4);
+  const rawRes = await callLLM(prompt);
+  let obj;
+  try { obj = JSON.parse(rawRes); } catch { obj = {}; }
+  const proposals = {};
+  for (const [k, v] of Object.entries(obj)) {
+    proposals[k] = v === null || v === undefined ? '' : String(v);
+  }
+  return { proposals, stats: { proposed_count: Object.keys(proposals).length, bytes_in: Buffer.byteLength(inputStr), tokens_est: tokens } };
+}
+
+module.exports = { fullFramePropose };


### PR DESCRIPTION
## Summary
- add llmFullFrame helper to propose allowlisted fields from full RAW context
- wire `full_frame` flag through API and intent resolver
- merge full-frame proposals before coverage reporting with debug trace

## Testing
- `npm test`
- `node - <<'NODE'
const buildLib = require('./lib/build');
buildLib.crawlSite = async () => [{url:'http://site.test',title:'Site Title',images:[],links:[],social:[],contacts:{ emails:[], phones:[] },headings:{ h1:[], h2:[], h3:[] }}];
const handler = require('./api/build');
const mockFetch = require('./test/helpers/mockFetch');
const resetEnv = require('./test/helpers/resetEnv');
resetEnv({ OPENAI_API_KEY: 'k' });
const restore = mockFetch({'https://api.openai.com/v1/chat/completions': [
  { json:{choices:[{message:{content:'{}'}}]} },
  { json:{choices:[{message:{content:'{"identity_owner_name":"Bob"}'}}]} }
]});
const req1 = { query:{ url:'http://site.test', push:'0', debug:'1' } };
const res1 = { status(c){ this.statusCode=c; return this; }, json(o){ this.body=o; } };
const req2 = { query:{ url:'http://site.test', push:'0', debug:'1', full_frame:'1' } };
const res2 = { status(c){ this.statusCode=c; return this; }, json(o){ this.body=o; } };
(async()=>{await handler(req1,res1);await handler(req2,res2);console.log('no flag stage', res1.body.debug.trace.some(t=>t.stage==='llm_full_frame'));console.log('with flag stage', res2.body.debug.trace.some(t=>t.stage==='llm_full_frame'));console.log('status1', res1.statusCode, 'status2', res2.statusCode);restore();})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68accb90cd24832a89228735bb9608a6