### PR TITLE
feat: add deterministic extractors and no-llm option

### DIFF
--- a/lib/detExtractors.js
+++ b/lib/detExtractors.js
@@ -1,0 +1,163 @@
+const EMAIL_RX = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
+const PHONE_RX = /^\+?[0-9 ][0-9 \-]{7,19}$/;
+const URL_RX = /^https?:\/\//i;
+const ABN_RX = /\b(?:\d\s*){11}\b/;
+
+function norm(s=''){ return String(s||'').trim(); }
+function safeJson(obj){
+  if (typeof obj === 'string') { try { return JSON.parse(obj); } catch { return undefined; } }
+  if (obj && typeof obj === 'object') return obj;
+  return undefined;
+}
+function getJsonLds(raw={}){
+  const arr = [];
+  for (const j of raw.jsonld || []) {
+    const obj = safeJson(j);
+    if (obj && typeof obj === 'object') arr.push(obj);
+  }
+  return arr;
+}
+
+function getEmail(raw={}){
+  for (const a of raw.anchors || []) {
+    const href = norm(a.href);
+    if (href.startsWith('mailto:')) {
+      const v = href.slice(7);
+      if (EMAIL_RX.test(v)) return { value: v.toLowerCase(), source: 'anchors' };
+    }
+    const m = href.match(EMAIL_RX) || norm(a.text).match(EMAIL_RX);
+    if (m) return { value: m[0].toLowerCase(), source: 'anchors' };
+  }
+  for (const j of getJsonLds(raw)) {
+    const v = norm(j.email);
+    if (EMAIL_RX.test(v)) return { value: v.toLowerCase(), source: 'jsonld' };
+  }
+  return { value: '', source: '' };
+}
+
+function getPhone(raw={}){
+  for (const a of raw.anchors || []) {
+    const href = norm(a.href);
+    if (href.startsWith('tel:')) {
+      const v = href.slice(4);
+      if (PHONE_RX.test(v)) return { value: v, source: 'anchors' };
+    }
+    const m = href.match(PHONE_RX) || norm(a.text).match(PHONE_RX);
+    if (m) return { value: m[0], source: 'anchors' };
+  }
+  for (const j of getJsonLds(raw)) {
+    const v = norm(j.telephone);
+    if (PHONE_RX.test(v)) return { value: v, source: 'jsonld' };
+  }
+  return { value: '', source: '' };
+}
+
+function getDomain(raw={}){
+  const meta = raw.meta || {};
+  const c = norm(meta.canonical || meta['og:url']);
+  if (URL_RX.test(c)) return { value: c, source: 'meta' };
+  for (const j of getJsonLds(raw)) {
+    const v = norm(j.url);
+    if (URL_RX.test(v)) return { value: v, source: 'jsonld' };
+  }
+  return { value: '', source: '' };
+}
+
+function getBusinessName(raw={}){
+  for (const j of getJsonLds(raw)) {
+    const t = norm(j['@type']);
+    if (/organization|localbusiness/i.test(t)) {
+      const v = norm(j.name);
+      if (v) return { value: v, source: 'jsonld' };
+    }
+  }
+  const meta = raw.meta || {};
+  const m = norm(meta['og:site_name'] || meta['og:title']);
+  if (m) return { value: m, source: 'meta' };
+  const h = raw.headings || [];
+  if (h[0] && norm(h[0].text)) return { value: norm(h[0].text), source: 'headings' };
+  return { value: '', source: '' };
+}
+
+function getLogoUrl(raw={}){
+  for (const j of getJsonLds(raw)) {
+    const v = norm(j.logo?.url || j.logo);
+    if (URL_RX.test(v)) return { value: v, source: 'jsonld' };
+  }
+  const meta = raw.meta || {};
+  const m = norm(meta['og:logo'] || meta['og:image']);
+  if (URL_RX.test(m)) return { value: m, source: 'meta' };
+  for (const img of raw.images || []) {
+    const alt = norm(img.alt).toLowerCase();
+    if (/logo|brand|icon/.test(alt)) {
+      const v = norm(img.src);
+      if (URL_RX.test(v)) return { value: v, source: 'images' };
+    }
+  }
+  return { value: '', source: '' };
+}
+
+function getABN(raw={}){
+  const texts = [];
+  for (const h of raw.headings || []) texts.push(norm(h.text));
+  for (const a of raw.anchors || []) { texts.push(norm(a.text)); texts.push(norm(a.href)); }
+  const meta = raw.meta || {};
+  for (const v of Object.values(meta)) texts.push(norm(v));
+  const joined = texts.join(' ');
+  const m = joined.match(ABN_RX);
+  return m ? { value: m[0].replace(/\s+/g,''), source: 'regex' } : { value: '', source: '' };
+}
+
+const SOCIAL_DOMAINS = {
+  social_links_facebook: ['facebook.com'],
+  social_links_instagram: ['instagram.com'],
+  social_links_linkedin: ['linkedin.com'],
+  social_links_twitter: ['twitter.com','x.com'],
+  social_links_youtube: ['youtube.com','youtu.be'],
+  social_links_tiktok: ['tiktok.com'],
+  social_links_pinterest: ['pinterest.com']
+};
+
+function getSocials(raw={}){
+  const out = {};
+  const add = (url, source) => {
+    try {
+      const u = new URL(url);
+      const host = u.hostname.replace(/^www\./,'').toLowerCase();
+      for (const [key, domains] of Object.entries(SOCIAL_DOMAINS)) {
+        if (out[key]?.value) continue;
+        for (const d of domains) {
+          if (host === d || host.endsWith('.'+d)) {
+            out[key] = { value: url, source };
+            return;
+          }
+        }
+      }
+    } catch {}
+  };
+  for (const a of raw.anchors || []) {
+    const href = norm(a.href);
+    if (URL_RX.test(href)) add(href, 'anchors');
+  }
+  for (const j of getJsonLds(raw)) {
+    const same = j.sameAs;
+    if (Array.isArray(same)) {
+      for (const u of same) add(norm(u), 'jsonld');
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  getEmail,
+  getPhone,
+  getDomain,
+  getBusinessName,
+  getLogoUrl,
+  getABN,
+  getSocials,
+  EMAIL_RX,
+  PHONE_RX,
+  URL_RX,
+  ABN_RX
+};

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -13,6 +13,7 @@ const {
 } = require('./resolve');
 const { fullFramePropose } = require('./llmFullFrame');
 const { readYaml } = require('./config');
+const det = require('./detExtractors');
 
 const resolveConfig = readYaml('config/resolve.yaml');
 
@@ -175,11 +176,44 @@ function passesValidation(val, rule = {}) {
   return true;
 }
 
-exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, fullFrame = false } = {}) {
+exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, fullFrame = false, opts = {} } = {}) {
   const trace = [];
   const allowSet = getAllowKeys();
   const map = imap.loadIntentMap();
-  const { fields, audit } = await runExecutor({ map, allowSet, raw, tradecard, llm, helpers });
+
+  const rawCounts = {
+    anchors: raw.anchors?.length || 0,
+    headings: raw.headings?.length || 0,
+    images: raw.images?.length || 0,
+    jsonld: raw.jsonld?.length || 0,
+    meta: Object.keys(raw.meta || {}).length
+  };
+  const byKey = {};
+  const add = (key, res, validator) => {
+    if (!allowSet.has(key)) return;
+    const cur = raw[key];
+    const curValid = cur && (!validator || validator(cur));
+    if (!curValid && res.value && (!validator || validator(res.value))) {
+      raw[key] = res.value;
+      byKey[key] = res.source;
+    }
+  };
+
+  add('identity_email', det.getEmail(raw), (v) => det.EMAIL_RX.test(v));
+  add('identity_phone', det.getPhone(raw), (v) => det.PHONE_RX.test(v));
+  add('identity_website_url', det.getDomain(raw), (v) => det.URL_RX.test(v));
+  add('identity_business_name', det.getBusinessName(raw), (v) => !!String(v).trim());
+  add('identity_abn', det.getABN(raw), (v) => det.ABN_RX.test(v));
+  add('brand_logo_url', det.getLogoUrl(raw), (v) => det.URL_RX.test(v));
+  const socials = det.getSocials(raw);
+  for (const [k, v] of Object.entries(socials)) {
+    add(k, v, (s) => det.URL_RX.test(s));
+  }
+
+  trace.push({ stage: 'det_summary', set: Object.keys(byKey).length, byKey, raw_counts: rawCounts });
+
+  const llmClient = opts.noLLM ? { resolveField: async () => '' } : llm;
+  const { fields, audit } = await runExecutor({ map, allowSet, raw, tradecard, llm: llmClient, helpers });
 
   const identity = resolveIdentity(raw);
   const social = resolveSocialLinks(raw.social, raw.gmb_lookup || {});
@@ -188,7 +222,7 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
 
   trace.push({ stage: 'rule_apply', audit });
 
-  if (fullFrame) {
+  if (fullFrame && !opts.noLLM) {
     const { proposals, stats } = await fullFramePropose({ raw, intentMap: map, resolveConfig, allowKeys: Array.from(allowSet), fixture: tradecard?.slug });
     const accepted = [];
     const rejected = [];


### PR DESCRIPTION
## Summary
- add pure deterministic extractors for basic org details, socials, ABN
- allow build API to skip LLM with `no_llm` flag and expose det_summary trace
- seed intent fields from deterministic pass and support det-only runs

## Testing
- `pnpm -s tsc -p . --noEmit` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `curl "$BASE/api/build?url=$TARGET&push=0&debug=1&no_llm=1"` *(fails: Failed to connect to localhost port 3000)*
- `curl -s "$BASE/api/build?url=$TARGET&push=0&debug=1&no_llm=1" | jq '[.debug.trace[]?|select(.stage=="intent_coverage")][0].after' | awk '{exit !($1>=10)}'` *(no output, server unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acea4e4300832a872eb97740a06d41