### PR TITLE
Ensure resolve-only requests always succeed

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -188,6 +188,7 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
     jsonld: raw.jsonld?.length || 0,
     meta: Object.keys(raw.meta || {}).length
   };
+  trace.push({ stage: 'intent_input', raw_counts: rawCounts });
   const byKey = {};
   const add = (key, res, validator) => {
     if (!allowSet.has(key)) return;


### PR DESCRIPTION
## Summary
- Guard thin payloads only when pushing to WordPress
- Return 200 with intent data and trace when push is disabled
- Emit `intent_input` trace early and keep coverage sampling after merges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad1c340938832ab7bacec52a11b161