### PR TITLE
feat: deterministic identity extraction

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -60,6 +60,7 @@ module.exports = async function handler(req, res) {
       images: (pages || [])
         .flatMap((p) => p.images || [])
         .map((i) => ({ src: i.src || '', alt: i.alt || '' })),
+      url: startUrl,
       meta: pages?.[0]?.meta || {},
       jsonld: pages?.[0]?.jsonld || pages?.[0]?.schema || []
     };

--- a/lib/detExtractors.js
+++ b/lib/detExtractors.js
@@ -1,5 +1,5 @@
 const EMAIL_RX = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
-const PHONE_RX = /^\+?[0-9 ]{8,20}$/;
+const PHONE_RX = /^\+?[0-9 ][0-9 \-]{7,19}$/;
 const URL_RX = /^https?:\/\//i;
 const ABN_RX = /(ABN|A\.?B\.?N\.?)[^\d]*((\d\s*){11})/i;
 
@@ -21,78 +21,85 @@ function getJsonLds(raw={}){
   return arr;
 }
 
-function getEmail(raw={}){
-  const texts=[];
-  for(const a of raw.anchors||[]){
-    const href=norm(a.href);
-    if(href.toLowerCase().startsWith('mailto:')){
-      const v=href.slice(7);
-      if(EMAIL_RX.test(v)) return { value:v.toLowerCase(), source:'anchors' };
+function getEmail(raw = {}) {
+  for (const j of getJsonLds(raw)) {
+    const v = norm(j.email);
+    if (EMAIL_RX.test(v)) return { value: v.toLowerCase(), source: 'jsonld' };
+  }
+  for (const a of raw.anchors || []) {
+    const href = norm(a.href);
+    if (href.toLowerCase().startsWith('mailto:')) {
+      const v = href.slice(7);
+      if (EMAIL_RX.test(v)) return { value: v.toLowerCase(), source: 'anchors' };
     }
-    texts.push(norm(a.text),href);
   }
-  const heads=raw.headings;
-  const arr=Array.isArray(heads)?heads:[...(heads?.h1||[]),...(heads?.h2||[]),...(heads?.h3||[])];
+  const texts = [];
+  for (const a of raw.anchors || []) texts.push(norm(a.text), norm(a.href));
+  const heads = raw.headings;
+  const arr = Array.isArray(heads) ? heads : [ ...(heads?.h1 || []), ...(heads?.h2 || []), ...(heads?.h3 || []) ];
   texts.push(...arr.map(norm));
-  for(const v of Object.values(raw.meta||{})) texts.push(norm(v));
-  const m=texts.join(' ').match(EMAIL_RX);
-  if(m) return { value:m[0].toLowerCase(), source:'regex' };
-  for(const j of getJsonLds(raw)){
-    const v=norm(j.email);
-    if(EMAIL_RX.test(v)) return { value:v.toLowerCase(), source:'jsonld' };
-  }
-  return { value:'', source:'' };
+  for (const v of Object.values(raw.meta || {})) texts.push(norm(v));
+  const m = texts.join(' ').match(EMAIL_RX);
+  return m ? { value: m[0].toLowerCase(), source: 'regex' } : { value: '', source: '' };
 }
 
-function getPhone(raw={}){
-  const scan=/\+?[0-9][0-9 \-]{7,19}/,normP=v=>{v=v.replace(/[^0-9+]+/g,' ').trim().replace(/\s+/g,' ');let d=v.replace(/\s+/g,'');if(d.startsWith('+'))return d;if(d.startsWith('0'))return '+61'+d.slice(1);if(!d.startsWith('61'))return '+61'+d;return '+'+d;};
-  const texts=[];
-  for(const a of raw.anchors||[]){
-    const href=norm(a.href);
-    if(href.toLowerCase().startsWith('tel:')){
-      const v=normP(href.slice(4));
-      if(PHONE_RX.test(v)) return { value:v, source:'anchors' };
+function getPhone(raw = {}) {
+  const scan = /\+?[0-9][0-9 \-]{7,19}/;
+  const normP = v => {
+    v = v.replace(/[^0-9+]+/g, ' ').trim().replace(/\s+/g, ' ');
+    let d = v.replace(/\s+/g, '');
+    if (d.startsWith('+')) return d;
+    if (d.startsWith('0')) return '+61' + d.slice(1);
+    if (!d.startsWith('61')) return '+61' + d;
+    return '+' + d;
+  };
+  for (const j of getJsonLds(raw)) {
+    const t = norm(j['@type']);
+    if (/organization|localbusiness/i.test(t)) {
+      const v = normP(norm(j.telephone));
+      if (PHONE_RX.test(v)) return { value: v, source: 'jsonld' };
     }
-    texts.push(norm(a.text),href);
   }
-  for(const j of getJsonLds(raw)){
-    const t=norm(j['@type']);
-    if(/organization|localbusiness/i.test(t)){
-      const v=normP(norm(j.telephone));
-      if(PHONE_RX.test(v)) return { value:v, source:'jsonld' };
+  for (const a of raw.anchors || []) {
+    const href = norm(a.href);
+    if (href.toLowerCase().startsWith('tel:')) {
+      const v = normP(href.slice(4));
+      if (PHONE_RX.test(v)) return { value: v, source: 'anchors' };
     }
   }
-  const heads=raw.headings;
-  const arr=Array.isArray(heads)?heads:[...(heads?.h1||[]),...(heads?.h2||[]),...(heads?.h3||[])];
+  const texts = [];
+  for (const a of raw.anchors || []) texts.push(norm(a.text), norm(a.href));
+  const heads = raw.headings;
+  const arr = Array.isArray(heads) ? heads : [ ...(heads?.h1 || []), ...(heads?.h2 || []), ...(heads?.h3 || []) ];
   texts.push(...arr.map(norm));
-  for(const v of Object.values(raw.meta||{})) texts.push(norm(v));
-  const m=texts.join(' ').match(scan);
-  if(m){
-    const v=normP(m[0]);
-    if(PHONE_RX.test(v)) return { value:v, source:'regex' };
+  for (const v of Object.values(raw.meta || {})) texts.push(norm(v));
+  const m = texts.join(' ').match(scan);
+  if (m) {
+    const v = normP(m[0]);
+    if (PHONE_RX.test(v)) return { value: v, source: 'regex' };
   }
-  return { value:'', source:'' };
+  return { value: '', source: '' };
 }
 
-function getDomain(raw={}){
-  for(const j of getJsonLds(raw)){
-    const t=norm(j['@type']);
-    if(/organization|localbusiness/i.test(t)){
-      const v=normUrl(j.url);
-      if(v) return { value:v, source:'jsonld' };
+function getDomain(raw = {}) {
+  for (const j of getJsonLds(raw)) {
+    const t = norm(j['@type']);
+    if (/organization|localbusiness/i.test(t)) {
+      const v = normUrl(j.url);
+      if (v) return { value: v, source: 'jsonld' };
     }
   }
-  const meta=raw.meta||{};
-  const m=normUrl(meta['og:url']);
-  if(m) return { value:m, source:'meta' };
-  const host=pickHost(raw.url);
-  if(host){
-    for(const a of raw.anchors||[]){
-      if(pickHost(normUrl(a.href))===host) return { value:'https://'+host, source:'anchors' };
+  const host = pickHost(raw.url);
+  if (host) {
+    for (const a of raw.anchors || []) {
+      if (pickHost(normUrl(a.href)) === host) return { value: 'https://' + host, source: 'anchors' };
     }
-    return { value:'https://'+host, source:'url' };
   }
-  return { value:'', source:'' };
+  const meta = raw.meta || {};
+  const m = normUrl(meta['og:url']);
+  if (m) return { value: m, source: 'meta' };
+  if (host) return { value: 'https://' + host, source: 'url' };
+  return { value: '', source: '' };
 }
 
 function getBusinessName(raw={}){
@@ -155,28 +162,28 @@ const SOCIAL_DOMAINS = {
   social_links_pinterest: ['pinterest.com']
 };
 
-function getSocials(raw={}){
-  const out={};
-  const add=(url,source)=>{
-    const u=normUrl(url);
-    if(!u) return;
-    const host=pickHost(u);
-    for(const [key,domains] of Object.entries(SOCIAL_DOMAINS)){
-      if(out[key]?.value) continue;
-      if(domains.some(d=>host===d||host.endsWith('.'+d))){
-        out[key]={ value:u, source };
+function getSocials(raw = {}) {
+  const out = {};
+  const add = (url, source) => {
+    const u = normUrl(url);
+    if (!u) return;
+    const host = pickHost(u);
+    for (const [key, domains] of Object.entries(SOCIAL_DOMAINS)) {
+      if (out[key]?.value) continue;
+      if (domains.some(d => host === d || host.endsWith('.' + d))) {
+        out[key] = { value: u, source };
         return;
       }
     }
   };
-  for(const a of raw.anchors||[]) add(a.href,'anchors');
-  for(const j of getJsonLds(raw)){
-    const t=norm(j['@type']);
-    if(/organization|localbusiness/i.test(t)){
-      const same=j.sameAs;
-      if(Array.isArray(same)) for(const u of same) add(u,'jsonld');
+  for (const j of getJsonLds(raw)) {
+    const t = norm(j['@type']);
+    if (/organization|localbusiness/i.test(t)) {
+      const same = j.sameAs;
+      if (Array.isArray(same)) for (const u of same) add(u, 'jsonld');
     }
   }
+  for (const a of raw.anchors || []) add(a.href, 'anchors');
   return out;
 }
 

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -205,7 +205,10 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
   add('identity_website_url', det.getDomain(raw), (v) => det.URL_RX.test(v));
   add('identity_business_name', det.getBusinessName(raw), (v) => !!String(v).trim());
   add('identity_abn', det.getABN(raw), (v) => det.ABN_RX.test(v));
-  add('brand_logo_url', det.getLogoUrl(raw), (v) => det.URL_RX.test(v));
+  const logoKey = allowSet.has('brand_logo_url')
+    ? 'brand_logo_url'
+    : (allowSet.has('identity_logo_url') ? 'identity_logo_url' : null);
+  if (logoKey) add(logoKey, det.getLogoUrl(raw), (v) => det.URL_RX.test(v));
   const socials = det.getSocials(raw);
   for (const [k, v] of Object.entries(socials)) {
     add(k, v, (s) => det.URL_RX.test(s));


### PR DESCRIPTION
## Summary
- add deterministic extractors for email, phone, domain, business name, logo, ABN and socials
- merge deterministic identity fields and socials before invoking any LLM and expose `det_summary` trace
- plumb `no_llm` flag through build API and provide page url for domain extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2b754098832a8e3624375842a5bb