### PR TITLE
feat: add unresolved LLM fallback

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -11,7 +11,7 @@ const {
   resolveTestimonial,
   similar,
 } = require('./resolve');
-const { fullFramePropose } = require('./llmFullFrame');
+const { proposeForUnresolved } = require('./llmFullFrame');
 const { readYaml } = require('./config');
 const det = require('./detExtractors');
 
@@ -226,18 +226,23 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
 
   trace.push({ stage: 'rule_apply', audit });
 
-  if (fullFrame && !opts.noLLM) {
-    const { proposals, stats } = await fullFramePropose({ raw, intentMap: map, resolveConfig, allowKeys: Array.from(allowSet), fixture: tradecard?.slug });
+  if (!opts.noLLM) {
+    const allowKeys = Array.from(allowSet);
+    const unresolvedKeys = allowKeys.filter((k) => (!fields[k] || fields[k] === '') && map[k]);
+    trace.push({ stage: 'llm_input', key_count: unresolvedKeys.length, has_raw: !!raw });
+    let proposals = {};
     const accepted = [];
     const rejected = [];
-    for (const [k, v] of Object.entries(proposals || {})) {
-      if (!allowSet.has(k)) { rejected.push({ key: k, reason: 'non-allowlisted' }); continue; }
-      const rule = imap.ruleFor(map, k);
-      if (fields[k] && passesValidation(fields[k], rule)) { rejected.push({ key: k, reason: 'already_set' }); continue; }
-      if (passesValidation(v, rule)) { fields[k] = String(v); accepted.push(k); }
-      else { rejected.push({ key: k, reason: 'failed-validate' }); }
+    if (unresolvedKeys.length) {
+      ({ proposals = {} } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, intentMap: map, resolveConfig, fixture: tradecard?.slug }));
+      for (const [k, v] of Object.entries(proposals)) {
+        const rule = imap.ruleFor(map, k);
+        if (fields[k] && passesValidation(fields[k], rule)) { rejected.push({ key: k, reason: 'already_set' }); continue; }
+        if (unresolvedKeys.includes(k) && passesValidation(v, rule)) { fields[k] = String(v); accepted.push(k); }
+        else { rejected.push({ key: k, reason: 'failed-validate' }); }
+      }
     }
-    trace.push({ stage: 'llm_full_frame', proposed: stats.proposed_count, accepted, rejected, has_raw: !!raw, approx_bytes: stats.bytes_in, approx_tokens: stats.tokens_est });
+    trace.push({ stage: 'llm_merge', proposed: Object.keys(proposals).length, accepted, rejected });
   }
 
   trace.push({ stage: 'intent_coverage', before: Object.keys(map).length, after: Object.keys(fields).length, sample_sent: Object.keys(fields).slice(0, 10) });

--- a/lib/llmFullFrame.js
+++ b/lib/llmFullFrame.js
@@ -2,87 +2,83 @@
 
 async function callLLM(payload) {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) return '{}';
+  if (!apiKey) return "{}";
   try {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: "gpt-4o-mini",
         temperature: 0,
-        response_format: { type: 'json_object' },
+        response_format: { type: "json_object" },
         messages: [
-          { role: 'system', content: 'Extract data and return only valid JSON.' },
-          { role: 'user', content: JSON.stringify(payload) }
+          { role: "system", content: "Extract data and return only valid JSON." },
+          { role: "user", content: JSON.stringify(payload) }
         ]
       })
     });
     const data = await res.json().catch(() => ({}));
-    return data?.choices?.[0]?.message?.content || '{}';
+    return data?.choices?.[0]?.message?.content || "{}";
   } catch {
-    return '{}';
+    return "{}";
   }
 }
 
-function prepareRaw(raw = {}) {
-  const buckets = {
-    anchors: raw.anchors || [],
-    headings: raw.headings || [],
-    images: raw.images || [],
-    jsonld: raw.jsonld || [],
-    meta: raw.meta || {}
+function compactRaw(raw = {}) {
+  const anchors = Array.isArray(raw.anchors) ? raw.anchors : [];
+  const headings = Array.isArray(raw.headings) ? raw.headings : [];
+  const images = Array.isArray(raw.images) ? raw.images : [];
+  const jsonld = Array.isArray(raw.jsonld) ? raw.jsonld : [];
+  const meta = raw.meta && typeof raw.meta === "object" ? raw.meta : {};
+  return {
+    anchors: anchors.slice(0, 50),
+    headings: headings.slice(0, 50),
+    images: images.slice(0, 50),
+    jsonld: jsonld.slice(0, 20),
+    meta: Object.fromEntries(Object.entries(meta).slice(0, 20)),
+    counts: {
+      anchors: anchors.length,
+      headings: headings.length,
+      images: images.length,
+      jsonld: jsonld.length,
+      meta: Object.keys(meta).length
+    }
   };
-  let out = buckets;
-  const MAX_BYTES = 12000;
-  let bytes = Buffer.byteLength(JSON.stringify(out));
-  if (bytes > MAX_BYTES) {
-    out = {
-      anchors: buckets.anchors.slice(0, 50),
-      headings: buckets.headings.slice(0, 50),
-      images: buckets.images.slice(0, 50),
-      jsonld: buckets.jsonld.slice(0, 20),
-      meta: Object.fromEntries(Object.entries(buckets.meta).slice(0, 20)),
-      counts: {
-        anchors: buckets.anchors.length,
-        headings: buckets.headings.length,
-        images: buckets.images.length,
-        jsonld: buckets.jsonld.length,
-        meta: Object.keys(buckets.meta).length
-      }
-    };
-    bytes = Buffer.byteLength(JSON.stringify(out));
-  }
-  return { raw: out, bytes };
 }
 
-async function fullFramePropose({ raw = {}, intentMap = {}, resolveConfig = {}, allowKeys = [], fixture = '' }) {
-  const { raw: safeRaw, bytes } = prepareRaw(raw);
+async function proposeForUnresolved({ raw = {}, allowKeys = [], unresolvedKeys = [], intentMap = {}, resolveConfig = {}, fixture = "" }) {
+  const keys = unresolvedKeys.filter((k) => allowKeys.includes(k));
   const fieldIntent = {};
-  for (const k of allowKeys) if (intentMap[k]) fieldIntent[k] = intentMap[k];
+  for (const k of keys) if (intentMap[k]) fieldIntent[k] = intentMap[k];
   const resolveCfg = {};
-  for (const k of allowKeys) if (resolveConfig[k]) resolveCfg[k] = resolveConfig[k];
-
+  for (const k of keys) if (resolveConfig[k]) resolveCfg[k] = resolveConfig[k];
+  const safeRaw = compactRaw(raw);
   const prompt = {
     fixture,
     ALLOW_KEYS: allowKeys,
+    UNRESOLVED_KEYS: keys,
     RAW: safeRaw,
     FIELD_INTENT: fieldIntent,
     RESOLVE_CONFIG: resolveCfg,
-    INSTRUCTION: 'Return a flat JSON object of {key: value} for keys ∈ allowKeys only. No new keys. Prefer exact strings from RAW; synthesize only when necessary and validate shape (email/phone/url/len). Return empty string for unknown.'
+    INSTRUCTION: "Return strict JSON {key:string} for keys ∈ unresolvedKeys∩allowKeys only. Prefer exact strings from RAW; synthesize only when absent; validate email/phone/url/len; '' if unknown."
   };
-  const inputStr = JSON.stringify(prompt);
-  const tokens = Math.ceil(Buffer.byteLength(inputStr) / 4);
+  const promptStr = JSON.stringify(prompt);
+  const approx_bytes = Buffer.byteLength(promptStr);
+  const approx_tokens = Math.ceil(approx_bytes / 4);
   const rawRes = await callLLM(prompt);
   let obj;
   try { obj = JSON.parse(rawRes); } catch { obj = {}; }
   const proposals = {};
-  for (const [k, v] of Object.entries(obj)) {
-    proposals[k] = v === null || v === undefined ? '' : String(v);
+  for (const k of keys) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) {
+      proposals[k] = obj[k] === null || obj[k] === undefined ? "" : String(obj[k]);
+    }
   }
-  return { proposals, stats: { proposed_count: Object.keys(proposals).length, bytes_in: Buffer.byteLength(inputStr), tokens_est: tokens } };
+  return { proposals, stats: { approx_tokens, approx_bytes } };
 }
 
-module.exports = { fullFramePropose };
+module.exports = { proposeForUnresolved };
+


### PR DESCRIPTION
## Summary
- add `proposeForUnresolved` to generate LLM proposals using compact raw frame and intent/resolve snippets
- integrate LLM fallback after deterministic merge with `llm_input` and `llm_merge` traces

## Testing
- `curl -s -o /tmp/out.json -w "%{http_code}\n" "http://localhost:3000/api/build?url=https://poolboysco.com.au&push=0&debug=1&no_llm=1"` *(fails: connection refused)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad30ee3ce4832ab5af6fa527bfdeb2