### PR TITLE
ci: add acceptance gates

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -1,0 +1,24 @@
+name: Acceptance
+on:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: accept-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  accept:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Run acceptance gates
+        env:
+          BASE: ${{ secrets.ACCEPT_BASE }}
+          TARGET: ${{ secrets.ACCEPT_TARGET }}
+          ACCEPT_MIN_COVERAGE: ${{ vars.ACCEPT_MIN_COVERAGE || 10 }}
+        run: bash scripts/accept.sh

--- a/scripts/accept.sh
+++ b/scripts/accept.sh
@@ -1,46 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-BASE=${BASE:-http://localhost:3000}
-TARGET=${1:-https://poolboysco.com.au}
-MIN=${MIN_ACF_KEYS:-10}
-MAX_PAGES=${MAX_PAGES:-5}
-MAX_DEPTH=${MAX_DEPTH:-1}
-
-jq_key() { jq -r "$1" 2>/dev/null || true; }
-
-# Health check
-if [ "$(curl -fsS "$BASE/api/health" | jq_key '.ok')" != "true" ]; then
-  echo "Health check failed at $BASE" >&2
-  exit 1
-fi
-printf "Health OK at %s\n" "$BASE"
-
-QS="url=$(printf %s "$TARGET")&resolve=llm&push=0&debug=1&maxPages=$MAX_PAGES&maxDepth=$MAX_DEPTH"
-RESP=$(curl -fsS "$BASE/api/build?$QS")
-
-echo "intent_input: $(printf %s "$RESP" | jq -c '.debug.trace[]?|select(.stage=="intent_input")')"
-echo "hint_extract: $(printf %s "$RESP" | jq -c '.debug.trace[]?|select(.stage=="hint_extract")')"
-echo "llm_resolve: $(printf %s "$RESP" | jq -c '.debug.trace[]?|select(.stage=="llm_resolve")|{sent}')"
-echo "intent_coverage: $(printf %s "$RESP" | jq -c '.debug.trace[]?|select(.stage=="intent_coverage")|{after}')"
-
-if [ -n "${WP_BASE:-}" ] && [ -n "${WP_BEARER:-}" ]; then
-  QS="url=$(printf %s "$TARGET")&resolve=llm&push=1&debug=1&maxPages=$MAX_PAGES&maxDepth=$MAX_DEPTH"
-  HTTP=$(curl -sS -w '\n%{http_code}\n' "$BASE/api/build?$QS")
-  BODY=$(printf %s "$HTTP" | head -n -1)
-  CODE=$(printf %s "$HTTP" | tail -n1)
-  if [ "$CODE" != "200" ]; then
-    printf "%s\n" "$BODY" | jq '{trace:(.debug.trace//[]|map(select(.stage=="intent_input" or .stage=="hint_extract" or .stage=="llm_resolve" or .stage=="intent_coverage")))}' || true
-    echo "Publish failed with $CODE" >&2
-    exit 1
-  fi
-  SENT=$(printf %s "$BODY" | jq '(.wordpress.details.steps[]?|select(.step=="acf_sync").sent_keys|length) // 0')
-  if [ "$SENT" -lt "$MIN" ]; then
-    printf "%s\n" "$BODY" | jq '{acf_sync:(.wordpress.details.steps[]?|select(.step=="acf_sync"))}' || true
-    echo "Publish sent $SENT < MIN($MIN)" >&2
-    exit 1
-  fi
-  echo "Publish OK with $SENT keys (>= $MIN)"
-else
-  echo "WP creds missing → skipping push step"
-fi
+: "${BASE:?Set BASE, e.g. http://localhost:3000}"
+: "${TARGET:?Set TARGET, e.g. https://poolboysco.com.au}"
+ACCEPT_MIN_COVERAGE="${ACCEPT_MIN_COVERAGE:-10}"
+TARGET_ENC=$(node -e "process.stdout.write(encodeURIComponent(process.env.TARGET))")
+echo "== Resolve-only must be 200 =="
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/build?url=$TARGET_ENC&push=0&debug=1") || true
+echo "resolve_code=$CODE"; test "$CODE" -eq 200
+echo "== Coverage floor = $ACCEPT_MIN_COVERAGE =="
+COV=$(curl -s "$BASE/api/build?url=$TARGET_ENC&push=0&debug=1" \
+  | jq -r '[.debug.trace[]?|select(.stage==\"intent_coverage\")][0].after // 0')
+echo "coverage_after=$COV"; test "${COV:-0}" -ge "$ACCEPT_MIN_COVERAGE"
+echo "== Push-only guard sanity (200 or 422) =="
+PCODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/build?url=$TARGET_ENC&push=1&debug=1") || true
+echo "push_code=$PCODE"; [[ "$PCODE" =~ ^(200|422)$ ]]
+echo "ACCEPTANCE OK"


### PR DESCRIPTION
## Summary
- add acceptance gate script verifying resolve 200, coverage floor, and push-only guard
- run gates in new GitHub Actions workflow on PRs

## Testing
- `bash -n scripts/accept.sh`
- `test -f .github/workflows/accept.yml && grep -q '^name: Acceptance' .github/workflows/accept.yml`
- `bash -lc 'test $(git diff --name-only | grep -vE "^(.github/workflows/accept.yml|scripts/accept.sh)$" | wc -l) -eq 0 && c=$(git diff --shortstat | awk "{print \$4}"); test "${c:-0}" -le 120'`


------
https://chatgpt.com/codex/tasks/task_e_68ad79699bc0832aa9f26f850ca8a99f