### PR TITLE
feat: send full raw data to LLM

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -230,7 +230,7 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
   if (!opts.noLLM) {
     const allowKeys = Array.from(allowSet);
     const unresolvedKeys = allowKeys.filter((k) => (!fields[k] || fields[k] === '') && map[k]);
-    trace.push({ stage: 'llm_input', key_count: unresolvedKeys.length, has_raw: !!raw });
+    trace.push({ stage: 'llm_input', key_count: allowKeys.length, has_raw: !!raw });
     let proposals = {};
     const accepted = [];
     const rejected = [];
@@ -238,8 +238,9 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
       ({ proposals = {} } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, intentMap: map, resolveConfig, fixture: tradecard?.slug, fullRaw: fullFrame }));
       for (const [k, v] of Object.entries(proposals)) {
         const rule = imap.ruleFor(map, k);
+        if (!allowSet.has(k)) { rejected.push({ key: k, reason: 'not_allowed' }); continue; }
         if (fields[k] && passesValidation(fields[k], rule)) { rejected.push({ key: k, reason: 'already_set' }); continue; }
-        if (unresolvedKeys.includes(k) && passesValidation(v, rule)) { fields[k] = String(v); accepted.push(k); }
+        if (passesValidation(v, rule)) { fields[k] = String(v); accepted.push(k); }
         else { rejected.push({ key: k, reason: 'failed-validate' }); }
       }
     }

--- a/lib/llmFullFrame.js
+++ b/lib/llmFullFrame.js
@@ -49,32 +49,49 @@ function compactRaw(raw = {}) {
   };
 }
 
-async function proposeForUnresolved({ raw = {}, allowKeys = [], unresolvedKeys = [], intentMap = {}, resolveConfig = {}, fixture = "", fullRaw = false }) {
-  const keys = unresolvedKeys.filter((k) => allowKeys.includes(k));
+async function proposeForUnresolved({
+  raw = {},
+  allowKeys = [],
+  unresolvedKeys = [],
+  intentMap = {},
+  resolveConfig = {},
+  fixture = "",
+  fullRaw = true,
+  maxTokens = 6e4
+}) {
+  const keys = Array.from(new Set([...allowKeys, ...unresolvedKeys]));
   const fieldIntent = {};
   for (const k of keys) if (intentMap[k]) fieldIntent[k] = intentMap[k];
   const resolveCfg = {};
   for (const k of keys) if (resolveConfig[k]) resolveCfg[k] = resolveConfig[k];
-  const safeRaw = fullRaw ? raw : compactRaw(raw);
-  const prompt = {
+  let safeRaw = fullRaw ? raw : compactRaw(raw);
+  let prompt = {
     fixture,
     ALLOW_KEYS: allowKeys,
-    UNRESOLVED_KEYS: keys,
+    REQUEST_KEYS: keys,
     RAW: safeRaw,
     FIELD_INTENT: fieldIntent,
     RESOLVE_CONFIG: resolveCfg,
-    INSTRUCTION: "Return strict JSON {key:string} for keys ∈ unresolvedKeys∩allowKeys only. Prefer exact strings from RAW; synthesize only when absent; validate email/phone/url/len; '' if unknown."
+    INSTRUCTION: "Return strict JSON {key:string} for keys ⊆ REQUEST_KEYS only. Prefer exact strings from RAW; synthesize only when absent; validate email/phone/url/len; '' if unknown.",
   };
-  const promptStr = JSON.stringify(prompt);
-  const approx_bytes = Buffer.byteLength(promptStr);
-  const approx_tokens = Math.ceil(approx_bytes / 4);
+  let promptStr = JSON.stringify(prompt);
+  let approx_bytes = Buffer.byteLength(promptStr);
+  let approx_tokens = Math.ceil(approx_bytes / 4);
+  if (approx_tokens > maxTokens && fullRaw) {
+    safeRaw = compactRaw(raw);
+    prompt.RAW = safeRaw;
+    promptStr = JSON.stringify(prompt);
+    approx_bytes = Buffer.byteLength(promptStr);
+    approx_tokens = Math.ceil(approx_bytes / 4);
+  }
   const rawRes = await callLLM(prompt);
   let obj;
   try { obj = JSON.parse(rawRes); } catch { obj = {}; }
   const proposals = {};
-  for (const k of keys) {
-    if (Object.prototype.hasOwnProperty.call(obj, k)) {
-      proposals[k] = obj[k] === null || obj[k] === undefined ? "" : String(obj[k]);
+  const allowSet = new Set(allowKeys);
+  for (const [k, v] of Object.entries(obj)) {
+    if (!allowSet.size || allowSet.has(k)) {
+      proposals[k] = v === null || v === undefined ? "" : String(v);
     }
   }
   return { proposals, stats: { approx_tokens, approx_bytes } };

--- a/test/llmFullFrame.test.js
+++ b/test/llmFullFrame.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { proposeForUnresolved } = require('../lib/llmFullFrame');
+
+test('uses full raw and returns allowed proposals', async () => {
+  const raw = { anchors: Array.from({ length: 60 }, (_, i) => ({ href: String(i) })) };
+  const allowKeys = ['foo', 'baz'];
+  const unresolvedKeys = ['foo'];
+  let sent;
+  const originalFetch = global.fetch;
+  const originalKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'test';
+  global.fetch = async (url, opts) => {
+    const body = JSON.parse(opts.body);
+    sent = JSON.parse(body.messages[1].content);
+    return { json: async () => ({ choices: [{ message: { content: '{"foo":"bar","baz":"qux","x":"y"}' } }] }) };
+  };
+  const { proposals } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, maxTokens: 1e6 });
+  assert.deepEqual(proposals, { foo: 'bar', baz: 'qux' });
+  assert.equal(sent.RAW.anchors.length, 60);
+  global.fetch = originalFetch;
+  process.env.OPENAI_API_KEY = originalKey;
+});
+
+test('compacts raw when prompt too large', async () => {
+  const raw = { anchors: Array.from({ length: 60 }, (_, i) => ({ href: String(i) })) };
+  const allowKeys = ['foo'];
+  const unresolvedKeys = ['foo'];
+  let sent;
+  const originalFetch = global.fetch;
+  const originalKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'test';
+  global.fetch = async (url, opts) => {
+    const body = JSON.parse(opts.body);
+    sent = JSON.parse(body.messages[1].content);
+    return { json: async () => ({ choices: [{ message: { content: '{"foo":"bar"}' } }] }) };
+  };
+  await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, maxTokens: 1 });
+  assert.equal(sent.RAW.anchors.length, 50);
+  global.fetch = originalFetch;
+  process.env.OPENAI_API_KEY = originalKey;
+});


### PR DESCRIPTION
## Summary
- send union of allowed keys and unresolved keys to LLM using full raw payload by default
- fall back to compacted raw when prompt grows too large and accept proposals for any allowed field
- exercise new behavior with unit tests for full raw handling and compaction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad805a27b4832a9b9e114d1b46e33f