### PR TITLE
Expose image alt text in parse results

### DIFF
--- a/api/build.js
+++ b/api/build.js
@@ -59,7 +59,7 @@ module.exports = async function handler(req, res) {
         .map((t) => t || ''),
       images: (pages || [])
         .flatMap((p) => p.images || [])
-        .map((i) => i.src || ''),
+        .map((i) => ({ src: i.url || '', alt: i.alt || '' })),
       url: startUrl,
       meta: pages?.[0]?.meta || {},
       jsonld: pages?.[0]?.jsonld || pages?.[0]?.schema || []

--- a/api/openapi.json.js
+++ b/api/openapi.json.js
@@ -127,6 +127,14 @@ const SPEC = {
           phones: { type: "array", items: { type: "string" } }
         }
       },
+      Image: {
+        type: "object",
+        properties: {
+          url: { type: "string", format: "uri" },
+          alt: { type: "string", nullable: true }
+        },
+        required: ["url"]
+      },
       Page: {
         type: "object",
         properties: {
@@ -140,7 +148,7 @@ const SPEC = {
               h3: { type: "array", items: { type: "string" } }
             }
           },
-          images: { type: "array", items: { type: "string", format: "uri" } },
+          images: { type: "array", items: { $ref: "#/components/schemas/Image" } },
           links:  { type: "array", items: { type: "string", format: "uri" } },
           social: { type: "array", items: { $ref: "#/components/schemas/SocialLink" } },
           contacts: { $ref: "#/components/schemas/Contacts" }

--- a/lib/build.js
+++ b/lib/build.js
@@ -73,7 +73,9 @@ function buildTradecardFromPages(startUrl, pages) {
   const domain = pickDomain(startUrl);
 
   const allLinks  = uniq(pages.flatMap(p => p.links  || []));
-  const allImages = uniq(pages.flatMap(p => p.images || [])).filter(isHttp);
+  const allImages = uniq(
+    pages.flatMap(p => (p.images || []).map(i => i.url))
+  ).filter(isHttp);
 
   const pageSocials = pages.flatMap(p => p.social || []);
   const pageEmails  = pages.flatMap(p => (p.contacts?.emails || []));

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -161,25 +161,29 @@ async function parse(html, pageUrl) {
 
   const images = [];
   const seen = new Set();
-  const add = (u, base = baseForResolve) => {
+  const add = (u, alt = null, base = baseForResolve) => {
     if (!u) return;
     try {
       const abs = new URL(u, base).toString();
       if (isHttp(abs)) {
         const c = clean(abs);
-        if (!seen.has(c)) { seen.add(c); images.push(c); }
+        if (!seen.has(c)) {
+          seen.add(c);
+          images.push({ url: c, alt: alt || null });
+        }
       }
     } catch {}
   };
 
   $('img').each((_, el) => {
     const $el = $(el);
-    add($el.attr('src'));
-    add($el.attr('data-src'));
-    add($el.attr('data-lazy-src'));
-    add($el.attr('data-original'));
+    const alt = $el.attr('alt') || null;
+    add($el.attr('src'), alt);
+    add($el.attr('data-src'), alt);
+    add($el.attr('data-lazy-src'), alt);
+    add($el.attr('data-original'), alt);
     const srcset = $el.attr('srcset');
-    if (srcset) srcset.split(',').forEach(p => add(p.trim().split(/\s+/)[0]));
+    if (srcset) srcset.split(',').forEach(p => add(p.trim().split(/\s+/)[0], alt));
   });
 
   $('[style*="background"]').each((_, el) => {
@@ -200,7 +204,7 @@ async function parse(html, pageUrl) {
   });
 
   const cssAssets = await collectCssAssets(Array.from(new Set([...sheetHrefs, ...importsInline])), baseForResolve, { maxFiles: 20, maxDepth: 2 });
-  cssAssets.forEach(u => add(u, pageUrl));
+  cssAssets.forEach(u => add(u, null, pageUrl));
 
   add($('link[rel="icon"]').attr('href'));
   add($('link[rel="apple-touch-icon"]').attr('href'));

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -98,6 +98,14 @@
           "phones": { "type": "array", "items": { "type": "string" } }
         }
       },
+      "Image": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string", "format": "uri" },
+          "alt": { "type": "string", "nullable": true }
+        },
+        "required": ["url"]
+      },
       "Page": {
         "type": "object",
         "properties": {
@@ -111,7 +119,7 @@
               "h3": { "type": "array", "items": { "type": "string" } }
             }
           },
-          "images": { "type": "array", "items": { "type": "string", "format": "uri" } },
+          "images": { "type": "array", "items": { "$ref": "#/components/schemas/Image" } },
           "links": { "type": "array", "items": { "type": "string", "format": "uri" } },
           "social": { "type": "array", "items": { "$ref": "#/components/schemas/SocialLink" } },
           "contacts": { "$ref": "#/components/schemas/Contacts" }

--- a/test/fixtures/simple.html
+++ b/test/fixtures/simple.html
@@ -14,8 +14,8 @@
   <h1>H1</h1>
   <h2>H2</h2>
   <h3>H3</h3>
-  <img src="http://example.com/dup.png?1" srcset="http://example.com/dup.png?2 2x">
-  <img data-src="http://example.com/other.png#section">
+  <img src="http://example.com/dup.png?1" srcset="http://example.com/dup.png?2 2x" alt="Duplicate">
+  <img data-src="http://example.com/other.png#section" alt="Lazy">
   <a href="mailto:info@example.com">mail</a>
   <a href="tel:+123456">phone</a>
   <a href="https://facebook.com/acme">fb</a>

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -18,8 +18,10 @@ test('parse extracts canonical images, headings, socials, contacts', async () =>
   assert.deepEqual(page.headings.h1, ['H1']);
   assert.deepEqual(page.headings.h2, ['H2']);
   assert.deepEqual(page.headings.h3, ['H3']);
-  assert.ok(page.images.every(u => u.startsWith('http://example.com/') && !u.includes('?') && !u.includes('#')));
-  assert.equal(new Set(page.images).size, page.images.length);
+  assert.ok(page.images.every(i => i.url.startsWith('http://example.com/') && !i.url.includes('?') && !i.url.includes('#')));
+  assert.equal(new Set(page.images.map(i => i.url)).size, page.images.length);
+  assert.equal(page.images.find(i => i.alt === 'Duplicate').url, 'http://example.com/dup.png');
+  assert.equal(page.images.find(i => i.alt === 'Lazy').url, 'http://example.com/other.png');
   const plats = ['facebook','instagram','linkedin','twitter','youtube','tiktok','pinterest'];
   for (const p of plats) {
     assert.ok(page.social.find(s => s.platform === p), `missing ${p}`);


### PR DESCRIPTION
## Summary
- include `<img>` alt text alongside image URLs in parse output
- propagate new `{url, alt}` image structure to build and API layers
- document image objects in OpenAPI schema and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad96ba2cc4832a8b3fddc876369d19