### PR TITLE
Capture free-text contact details

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3,6 +3,16 @@
 
 const cheerio = require('cheerio');
 const { ALLOWED_PROTOCOLS } = require('./fetch_html');
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+const PHONE_RE = /\+?\d[\d\s()-]{7,}\d/g;
+
+function normPhone(p) {
+  let s = String(p || '').replace(/[\s()-]/g, '').trim();
+  if (!s) return '';
+  if (s.startsWith('+')) return '+' + s.slice(1).replace(/\D/g, '');
+  if (s.startsWith('0')) return '+61' + s.slice(1).replace(/\D/g, '');
+  return '+' + s.replace(/\D/g, '');
+}
 
 const isHttp = (u) => { try { return ALLOWED_PROTOCOLS.has(new URL(u).protocol); } catch { return false; } };
 const clean = (abs) => { try { const u = new URL(abs); u.search=''; u.hash=''; return u.toString(); } catch { return abs; } };
@@ -222,6 +232,7 @@ async function parse(html, pageUrl) {
     .get()
     .filter(Boolean);
   const links = anchors.map((a) => a.href);
+  const bodyText = $('body').text();
 
   const meta = {};
   $('meta').each((_, el) => {
@@ -327,10 +338,18 @@ async function parse(html, pageUrl) {
     if (platform) socials.push({ platform, url: href });
   }
 
+  EMAIL_RE.lastIndex = 0;
+  PHONE_RE.lastIndex = 0;
+  let m;
+  while ((m = EMAIL_RE.exec(bodyText))) emails.push(m[0]);
+  while ((m = PHONE_RE.exec(bodyText))) {
+    if (m[0].replace(/\D/g, '').length >= 8) phones.push(m[0]);
+  }
+
   const uniqBy = (arr, keyer) => Array.from(new Map(arr.map(v => [keyer(v), v])).values());
   const uniqueSocials = uniqBy(socials, s => `${s.platform}:${s.url}`);
-  const uniqueEmails  = Array.from(new Set(emails));
-  const uniquePhones  = Array.from(new Set(phones));
+  const uniqueEmails  = Array.from(new Set(emails.map(e => String(e).toLowerCase().trim()).filter(Boolean)));
+  const uniquePhones  = Array.from(new Set(phones.map(normPhone).filter(Boolean)));
 
 
   const testimonialContainers =
@@ -425,7 +444,6 @@ async function parse(html, pageUrl) {
     }
   }
 
-  const bodyText = $('body').text();
   const abnMatch = /ABN\s*[:#-]?\s*([0-9\s]{9,20})/i.exec(bodyText);
   const abn = abnMatch ? abnMatch[1].replace(/\s+/g, '') : null;
   const insuredMatch = /(fully\s+insured[^\n]*|insurance[^\n]*)/i.exec(bodyText);

--- a/test/fixtures/free_text_contact.html
+++ b/test/fixtures/free_text_contact.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head><title>Free Text Contact</title></head>
+<body>
+<p>Call us at 0400 123 456 or email contact@example.com for info.</p>
+<a href="tel:0400123456">Phone</a>
+<a href="mailto:contact@example.com">Email</a>
+</body>
+</html>

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -28,6 +28,15 @@ test('parse extracts canonical images, headings, socials, contacts', async () =>
   assert.deepEqual(page.contacts.phones, ['+123456']);
 });
 
+test('parse finds contacts in free text', async () => {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures/free_text_contact.html'), 'utf8');
+  const page = await parse(html, 'http://example.com');
+  assert.deepEqual(page.contacts.emails, ['contact@example.com']);
+  assert.deepEqual(page.contacts.phones, ['+61400123456']);
+  assert.equal(page.identity_email, 'contact@example.com');
+  assert.equal(page.identity_phone, '+61400123456');
+});
+
 test('parse captures videos, contact forms and awards', async () => {
   const html = fs.readFileSync(path.join(__dirname, 'fixtures/trust_theme.html'), 'utf8');
   const page = await parse(html, 'https://example.com');


### PR DESCRIPTION
## Summary
- parse body text for phone numbers and emails with regexes
- merge free-text contacts into deduplicated arrays and identity fields
- add tests for free-text contact extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad96bbdc4c832a9c13092d116b58c3