### PR TITLE
Parse JSON-LD for identity fields

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -327,12 +327,6 @@ async function parse(html, pageUrl) {
     if (platform) socials.push({ platform, url: href });
   }
 
-  const uniqBy = (arr, keyer) => Array.from(new Map(arr.map(v => [keyer(v), v])).values());
-  const uniqueSocials = uniqBy(socials, s => `${s.platform}:${s.url}`);
-  const uniqueEmails  = Array.from(new Set(emails));
-  const uniquePhones  = Array.from(new Set(phones));
-
-
   const testimonialContainers =
     $("[class*='testimonial'],[id*='testimonial'],[class*='review'],[id*='review']")
       .filter((_, el) => !$(el).parents("[class*='testimonial'],[id*='testimonial'],[class*='review'],[id*='review']").length);
@@ -399,7 +393,7 @@ async function parse(html, pageUrl) {
   const projects = parseProjects($, baseForResolve);
 
   // Owner name/title/headshot
-  const ownerName =
+  let ownerName =
     $('.owner .name').first().text().trim() ||
     $('[data-owner-name]').first().text().trim() ||
     null;
@@ -411,10 +405,12 @@ async function parse(html, pageUrl) {
     $('.owner img').first().attr('src') ||
     $('img[alt*="headshot" i]').first().attr('src') ||
     null;
+  let identityBusinessName = null;
+  let identityLogoUrl = null;
 
   // Address/suburb/state/ABN/insurance text
   const addrText = $('address').first().text() || $('.address').first().text() || '';
-  const addressFull = norm(addrText) || null;
+  let addressFull = norm(addrText) || null;
   let suburb, state;
   if (addressFull) {
     const parts = addressFull.split(',').map((p) => p.trim());
@@ -442,6 +438,69 @@ async function parse(html, pageUrl) {
     if (!addressUri && /(google\.com\/maps|goo\.gl\/maps|maps\.app\.goo\.gl)/.test(low)) addressUri = href;
   }
 
+  // JSON-LD Person/Organization enrichment
+  const entities = [];
+  const visit = (node) => {
+    if (!node) return;
+    if (Array.isArray(node)) { node.forEach(visit); return; }
+    if (typeof node !== 'object') return;
+    if (node['@graph']) { visit(node['@graph']); }
+    else entities.push(node);
+  };
+  jsonld.forEach(visit);
+  for (const ent of entities) {
+    const types = [].concat(ent['@type'] || []);
+    const isPerson = types.includes('Person');
+    const isOrg = types.includes('Organization');
+    if (!isPerson && !isOrg) continue;
+    const nm = ent.name || ent.legalName;
+    if (isPerson && !ownerName && nm) ownerName = String(nm).trim();
+    if (isOrg && !identityBusinessName && nm) identityBusinessName = String(nm).trim();
+    if (!identityLogoUrl && ent.logo) {
+      let logo = ent.logo;
+      if (typeof logo === 'object') logo = logo.url || logo['@id'];
+      identityLogoUrl = resolveUrl(logo, baseForResolve);
+    }
+    if (ent.telephone) phones.push(String(ent.telephone).trim());
+    if (ent.email) emails.push(String(ent.email).trim());
+    if (!addressFull && ent.address) {
+      if (typeof ent.address === 'string') addressFull = ent.address.trim();
+      else if (typeof ent.address === 'object') {
+        const a = ent.address;
+        const parts = [a.streetAddress, a.addressLocality, a.addressRegion, a.postalCode]
+          .filter(Boolean);
+        addressFull = parts.join(', ');
+        if (!suburb && a.addressLocality) suburb = a.addressLocality;
+        if (!state && a.addressRegion) {
+          const stMatch = /(NSW|QLD|VIC|WA|SA|TAS|ACT|NT)/i.exec(a.addressRegion);
+          if (stMatch) state = stMatch[1].toUpperCase();
+        }
+      }
+    }
+    if (ent.sameAs) {
+      const arr = Array.isArray(ent.sameAs) ? ent.sameAs : [ent.sameAs];
+      for (const url of arr) {
+        if (!url) continue;
+        const low = String(url).toLowerCase();
+        const platform =
+          low.includes('facebook.com')  ? 'facebook'  :
+          low.includes('instagram.com') ? 'instagram' :
+          (low.includes('x.com') || low.includes('twitter.com')) ? 'twitter' :
+          low.includes('linkedin.com')  ? 'linkedin'  :
+          (low.includes('youtube.com') || low.includes('youtu.be')) ? 'youtube' :
+          low.includes('tiktok.com')    ? 'tiktok'    :
+          low.includes('pinterest.')    ? 'pinterest' :
+          null;
+        if (platform) socials.push({ platform, url: String(url) });
+      }
+    }
+  }
+
+  const uniqBy = (arr, keyer) => Array.from(new Map(arr.map(v => [keyer(v), v])).values());
+  const uniqueSocials = uniqBy(socials, s => `${s.platform}:${s.url}`);
+  const uniqueEmails  = Array.from(new Set(emails));
+  const uniquePhones  = Array.from(new Set(phones));
+
   // Service tags
   const serviceTags = $('.tag').map((_, el) => norm($(el).text())).get().filter(Boolean);
 
@@ -466,6 +525,8 @@ async function parse(html, pageUrl) {
     identity_owner_name: ownerName,
     identity_role_title: ownerTitle,
     identity_headshot_url: headshotUrl,
+    identity_business_name: identityBusinessName,
+    identity_logo_url: identityLogoUrl,
     identity_suburb: suburb,
     identity_state: state,
     identity_abn: abn,

--- a/test/fixtures/jsonld-org.html
+++ b/test/fixtures/jsonld-org.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Acme Corp",
+  "logo": "/logo.png",
+  "address": {
+    "streetAddress": "123 Street",
+    "addressLocality": "Townsville",
+    "addressRegion": "NSW"
+  },
+  "telephone": "+61 2 1234 5678",
+  "sameAs": [
+    "https://facebook.com/acme",
+    "https://twitter.com/acme"
+  ]
+}
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/test/fixtures/jsonld-person.html
+++ b/test/fixtures/jsonld-person.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "John Smith",
+  "telephone": "+1 555 000",
+  "sameAs": "https://instagram.com/johnsmith"
+}
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -49,3 +49,22 @@ test('parse extracts on-site testimonials', async () => {
     job_type: 'Deck installation'
   });
 });
+
+test('parse enriches identity fields from Organization JSON-LD', async () => {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures/jsonld-org.html'), 'utf8');
+  const page = await parse(html, 'http://example.com');
+  assert.equal(page.identity_business_name, 'Acme Corp');
+  assert.equal(page.identity_logo_url, 'http://example.com/logo.png');
+  assert.equal(page.identity_address, '123 Street, Townsville, NSW');
+  assert.equal(page.identity_phone, '+61 2 1234 5678');
+  assert.ok(page.social.find(s => s.platform === 'facebook' && s.url === 'https://facebook.com/acme'));
+  assert.ok(page.social.find(s => s.platform === 'twitter' && s.url === 'https://twitter.com/acme'));
+});
+
+test('parse enriches identity fields from Person JSON-LD', async () => {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures/jsonld-person.html'), 'utf8');
+  const page = await parse(html, 'http://example.com');
+  assert.equal(page.identity_owner_name, 'John Smith');
+  assert.equal(page.identity_phone, '+1 555 000');
+  assert.ok(page.social.find(s => s.platform === 'instagram' && s.url === 'https://instagram.com/johnsmith'));
+});


### PR DESCRIPTION
## Summary
- extract Person and Organization data from JSON-LD in `parse`
- fill identity fields such as name, logo, address, phone and socials when HTML lacks them
- test parsing of representative JSON-LD snippets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad96bcb480832ab013dbbd2dc381a7