### PR TITLE
Expose page language from <html>

### DIFF
--- a/api/openapi.json.js
+++ b/api/openapi.json.js
@@ -32,7 +32,7 @@ const SPEC = {
       get: {
         operationId: "scrapePage",
         summary: "Scrape a single page",
-        description: "Fetches one page and returns title, headings (h1–h3), images (including CSS backgrounds), absolute links, plus socials and contacts derived from links.",
+        description: "Fetches one page and returns language, title, headings (h1–h3), images (including CSS backgrounds), absolute links, plus socials and contacts derived from links.",
         parameters: [
           { name: "url", in: "query", required: true, schema: { type: "string", format: "uri" }, description: "Absolute http(s) URL to scrape" },
           { name: "limitImages", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 500 }, description: "Cap number of images returned" },
@@ -57,7 +57,7 @@ const SPEC = {
       get: {
         operationId: "crawlSite",
         summary: "Crawl a site (same-origin)",
-        description: "Breadth-first traversal from the start URL, same-origin by default. Aggregates page data but does not build a TradeCard.",
+        description: "Breadth-first traversal from the start URL, same-origin by default. Aggregates page data (including language) but does not build a TradeCard.",
         parameters: [
           { name: "url", in: "query", required: true, schema: { type: "string", format: "uri" } },
           { name: "maxPages", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 50, default: 10 } },
@@ -132,6 +132,7 @@ const SPEC = {
         properties: {
           url: { type: "string", format: "uri" },
           title: { type: "string", nullable: true },
+          page_language: { type: "string", nullable: true },
           headings: {
             type: "object",
             properties: {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -146,6 +146,7 @@ async function collectCssAssets(entryUrls, baseForResolve, { maxFiles = 20, maxD
 
 async function parse(html, pageUrl) {
   const $ = cheerio.load(html);
+  const pageLanguage = ($('html').attr('lang') || '').trim() || null;
   const norm = (t) => (t || '').replace(/\s+/g, ' ').trim();
 
   let baseForResolve = pageUrl;
@@ -448,6 +449,7 @@ async function parse(html, pageUrl) {
   return {
     url: pageUrl,
     title,
+    page_language: pageLanguage,
     headings,
     images,
     links,

--- a/test/fixtures/simple.html
+++ b/test/fixtures/simple.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <title>Simple Page</title>
   <link rel="stylesheet" href="http://example.com/style.css">

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -15,6 +15,7 @@ test('parse extracts canonical images, headings, socials, contacts', async () =>
   restore();
 
   assert.equal(page.title, 'Simple Page');
+  assert.equal(page.page_language, 'en');
   assert.deepEqual(page.headings.h1, ['H1']);
   assert.deepEqual(page.headings.h2, ['H2']);
   assert.deepEqual(page.headings.h3, ['H3']);


### PR DESCRIPTION
## Summary
- capture `<html lang>` attribute during parsing and expose as `page_language`
- document new field in OpenAPI spec and add coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad96be0e38832a8ffc1f382dc86282