### PR TITLE
Integrate MVF resolver into intent pipeline

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -1,6 +1,7 @@
 const { getAllowKeys } = require('./acf_contract');
 const imap = require('./intent_map');
 const { runExecutor } = require('./executor');
+const { resolveMVF } = require('./mvf_resolver');
 const llm = require('./llm_resolver');
 const {
   resolveIdentity,
@@ -221,6 +222,19 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
 
   const llmClient = opts.noLLM ? { resolveField: async () => '' } : llm;
   const { fields, audit } = await runExecutor({ map, allowSet, raw, tradecard, llm: llmClient, helpers });
+
+  const mvf = await resolveMVF({ raw, tradecard, allowKeys: allowSet });
+  const mvfFields = mvf.fields || {};
+  const mvfAudit = mvf.audit || [];
+  const mvfSupplied = Object.keys(mvfFields).length;
+  const mvfMerged = [];
+  for (const [k, v] of Object.entries(mvfFields)) {
+    if (fields[k]) continue;
+    fields[k] = v;
+    mvfMerged.push(k);
+  }
+  if (mvfAudit.length) audit.push(...mvfAudit);
+  trace.push({ stage: 'mvf_merge', supplied: mvfSupplied, merged: mvfMerged.length });
 
   const identity = resolveIdentity(raw);
   const social = resolveSocialLinks(raw.social, raw.gmb_lookup || {});

--- a/test/intent.mvf.test.js
+++ b/test/intent.mvf.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { applyIntent } = require('../lib/intent');
+
+test('applyIntent uses MVF resolver to populate uri and service areas', async () => {
+  const raw = {
+    anchors: [{ href: 'tel:0412 345 678' }],
+    headings: ['Sydney', 'Newcastle']
+  };
+  const { fields, trace } = await applyIntent({}, { raw, opts: { noLLM: true } });
+  assert.ok(fields.identity_uri_phone);
+  assert.equal(fields.service_areas_csv, 'Sydney,Newcastle');
+  const mvfTrace = trace.find((t) => t.stage === 'mvf_merge');
+  assert.ok(mvfTrace);
+  assert.ok(mvfTrace.supplied >= 2);
+});


### PR DESCRIPTION
## Summary
- call deterministic `resolveMVF` inside `applyIntent` and merge non-conflicting fields
- record MVF audit info in trace
- add test covering MVF population of contact URI and service areas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada7c0a9c4832abf1ace621a1589e9