### PR TITLE
feat: expand page parser with rich metadata extraction

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -211,6 +211,7 @@ async function parse(html, pageUrl) {
     const rel = (($(el).attr('rel') || '') + '').toLowerCase();
     return /\bstylesheet\b/.test(rel) || (/\b(preload|prefetch)\b/.test(rel) && ($(el).attr('as') || '') === 'style');
   }).map((_, el) => $(el).attr('href')).get();
+  const stylesheetCount = sheetHrefs.length;
 
   const importsInline = [];
   $('style').each((_, el) => {
@@ -220,10 +221,14 @@ async function parse(html, pageUrl) {
   const cssAssets = await collectCssAssets(Array.from(new Set([...sheetHrefs, ...importsInline])), baseForResolve, { maxFiles: 20, maxDepth: 2 });
   cssAssets.forEach(u => add(u, null, pageUrl));
 
-  add($('link[rel="icon"]').attr('href'));
-  add($('link[rel="apple-touch-icon"]').attr('href'));
+  const faviconHref = $('link[rel="icon"]').attr('href');
+  const appleIconHref = $('link[rel="apple-touch-icon"]').attr('href');
+  add(faviconHref);
+  add(appleIconHref);
   add($('meta[property="og:image"]').attr('content'));
   add($('meta[name="twitter:image"]').attr('content'));
+
+  const scriptCount = $('script').length;
 
   const anchors = $('a[href]')
     .map((_, el) => {
@@ -250,7 +255,34 @@ async function parse(html, pageUrl) {
     if (name && content) meta[name] = content.trim();
   });
   const canon = $('link[rel="canonical"]').attr('href');
-  if (canon) meta.canonical = canon;
+  const canonicalUrl = canon ? resolveUrl(canon, baseForResolve) : null;
+  if (canonicalUrl) meta.canonical = canonicalUrl;
+
+  const metaDescription = meta['description'] || null;
+  const metaKeywords = meta['keywords'] || null;
+  const metaRobots = meta['robots'] || null;
+  const metaAuthor = meta['author'] || null;
+  const metaGenerator = meta['generator'] || null;
+  const metaViewport = meta['viewport'] || null;
+  const metaCharset = $('meta[charset]').attr('charset') || null;
+  const metaThemeColor = meta['theme-color'] || null;
+
+  const ogTitle = meta['og:title'] || null;
+  const ogDescription = meta['og:description'] || null;
+  const ogImage = meta['og:image'] ? resolveUrl(meta['og:image'], baseForResolve) : null;
+  const ogUrl = meta['og:url'] ? resolveUrl(meta['og:url'], baseForResolve) : null;
+  const ogType = meta['og:type'] || null;
+  const ogSiteName = meta['og:site_name'] || null;
+
+  const twitterCard = meta['twitter:card'] || null;
+  const twitterTitle = meta['twitter:title'] || null;
+  const twitterDescription = meta['twitter:description'] || null;
+  const twitterImage = meta['twitter:image'] ? resolveUrl(meta['twitter:image'], baseForResolve) : null;
+  const twitterSite = meta['twitter:site'] || null;
+  const twitterCreator = meta['twitter:creator'] || null;
+
+  const faviconUrl = resolveUrl(faviconHref, baseForResolve);
+  const appleTouchIconUrl = resolveUrl(appleIconHref, baseForResolve);
 
   const jsonld = [];
   $('script[type="application/ld+json"]').each((_, el) => {
@@ -281,6 +313,14 @@ async function parse(html, pageUrl) {
   const contact_forms = [];
   const awards = [];
   const cssVars = {};
+
+  const pageOrigin = (() => { try { return new URL(pageUrl).origin; } catch { return null; } })();
+  let linkInternalCount = 0;
+  let linkExternalCount = 0;
+  let linkMailtoCount = 0;
+  let linkTelCount = 0;
+  let linkSmsCount = 0;
+  let linkWhatsappCount = 0;
 
   const collectVars = (css = '') => {
     const re = /--([a-z0-9_-]+):\s*([^;]+);/gi;
@@ -325,14 +365,32 @@ async function parse(html, pageUrl) {
     if (!href) continue;
     const low = href.toLowerCase();
     if (low.startsWith('mailto:')) {
+      linkMailtoCount++;
       const addr = href.replace(/^mailto:/i, '').trim();
       if (addr) emails.push(addr);
       continue;
     }
     if (low.startsWith('tel:')) {
+      linkTelCount++;
       const tel = href.replace(/^tel:/i, '').trim();
       if (tel) phones.push(tel);
       continue;
+    }
+    if (low.startsWith('sms:')) {
+      linkSmsCount++;
+      continue;
+    }
+    if (low.includes('wa.me') || low.includes('whatsapp')) {
+      linkWhatsappCount++;
+    }
+    if (pageOrigin) {
+      try {
+        const u = new URL(href);
+        if (u.origin === pageOrigin) linkInternalCount++;
+        else linkExternalCount++;
+      } catch {
+        linkExternalCount++;
+      }
     }
     const platform =
       low.includes('facebook.com')  ? 'facebook'  :
@@ -522,6 +580,20 @@ async function parse(html, pageUrl) {
     }
   }
 
+  const wordCount = bodyText.trim().split(/\s+/).filter(Boolean).length;
+  const characterCount = bodyText.length;
+  const firstParagraphText = norm($('p').first().text()) || null;
+  const imageCount = images.length;
+  const firstImageUrl = images[0] ? images[0].url : null;
+  const jsonldCount = jsonld.length;
+  const microdataItemtypes = Array.from(new Set($('[itemtype]').map((_, el) => $(el).attr('itemtype')).get().filter(Boolean)));
+  const h1Count = headings.h1.length;
+  const h2Count = headings.h2.length;
+  const h3Count = headings.h3.length;
+  const h4Count = headings.h4.length;
+  const h5Count = headings.h5.length;
+  const h6Count = headings.h6.length;
+
   const uniqBy = (arr, keyer) => Array.from(new Map(arr.map(v => [keyer(v), v])).values());
   const uniqueSocials = uniqBy(socials, s => `${s.platform}:${s.url}`);
   const uniqueEmails  = Array.from(new Set(emails.map(e => String(e).toLowerCase().trim()).filter(Boolean)));
@@ -534,13 +606,57 @@ async function parse(html, pageUrl) {
     url: pageUrl,
     title,
     page_language: pageLanguage,
+    canonical_url: canonicalUrl,
+    meta_description: metaDescription,
+    meta_keywords: metaKeywords,
+    meta_robots: metaRobots,
+    meta_author: metaAuthor,
+    meta_generator: metaGenerator,
+    meta_viewport: metaViewport,
+    meta_charset: metaCharset,
+    meta_theme_color: metaThemeColor,
+    og_title: ogTitle,
+    og_description: ogDescription,
+    og_image: ogImage,
+    og_url: ogUrl,
+    og_type: ogType,
+    og_site_name: ogSiteName,
+    twitter_card: twitterCard,
+    twitter_title: twitterTitle,
+    twitter_description: twitterDescription,
+    twitter_image: twitterImage,
+    twitter_site: twitterSite,
+    twitter_creator: twitterCreator,
+    favicon_url: faviconUrl,
+    apple_touch_icon_url: appleTouchIconUrl,
     headings,
+    h1_count: h1Count,
+    h2_count: h2Count,
+    h3_count: h3Count,
+    h4_count: h4Count,
+    h5_count: h5Count,
+    h6_count: h6Count,
     images,
+    image_count: imageCount,
     links,
     anchors,
+    link_internal_count: linkInternalCount,
+    link_external_count: linkExternalCount,
+    link_mailto_count: linkMailtoCount,
+    link_tel_count: linkTelCount,
+    link_sms_count: linkSmsCount,
+    link_whatsapp_count: linkWhatsappCount,
+    script_count: scriptCount,
+    stylesheet_count: stylesheetCount,
     meta,
     jsonld,
+    jsonld_count: jsonldCount,
+    microdata_itemtypes: microdataItemtypes,
     text_blocks,
+    word_count: wordCount,
+    character_count: characterCount,
+    first_paragraph_text: firstParagraphText,
+    first_image_url: firstImageUrl,
     social: uniqueSocials,
     contacts: { emails: uniqueEmails, phones: uniquePhones },
     profile_videos,

--- a/test/fixtures/meta.html
+++ b/test/fixtures/meta.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Meta Page</title>
+  <link rel="canonical" href="https://example.com/canonical">
+  <link rel="icon" href="/favicon.ico">
+  <link rel="apple-touch-icon" href="/apple.png">
+  <meta name="description" content="Desc">
+  <meta name="keywords" content="a,b">
+  <meta name="robots" content="index,follow">
+  <meta name="author" content="Author">
+  <meta name="generator" content="Gen">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="utf-8">
+  <meta name="theme-color" content="#ff0000">
+  <meta property="og:title" content="OG Title">
+  <meta property="og:description" content="OG Desc">
+  <meta property="og:image" content="/og.png">
+  <meta property="og:url" content="https://example.com/og">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="OG Site">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="TW Title">
+  <meta name="twitter:description" content="TW Desc">
+  <meta name="twitter:image" content="/tw.png">
+  <meta name="twitter:site" content="@twsite">
+  <meta name="twitter:creator" content="@twcreator">
+</head>
+<body>
+  <p>First paragraph.</p>
+  <a href="mailto:test@example.com">Email</a>
+  <a href="tel:+123456789">Call</a>
+  <a href="sms:+123456789">SMS</a>
+  <a href="https://wa.me/123456789">WA</a>
+  <a href="/internal">Internal</a>
+  <a href="https://external.com">External</a>
+  <script></script>
+  <script></script>
+  <link rel="stylesheet" href="/style.css">
+</body>
+</html>

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -83,3 +83,25 @@ test('parse enriches identity fields from Person JSON-LD', async () => {
   assert.equal(page.identity_phone, '+1555000');
   assert.ok(page.social.find(s => s.platform === 'instagram' && s.url === 'https://instagram.com/johnsmith'));
 });
+
+test('parse extracts extended meta fields and counts', async () => {
+  const restore = mockFetch({ 'https://example.com/style.css': { body: '' } });
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures/meta.html'), 'utf8');
+  const page = await parse(html, 'https://example.com');
+  restore();
+  assert.equal(page.canonical_url, 'https://example.com/canonical');
+  assert.equal(page.meta_description, 'Desc');
+  assert.equal(page.og_title, 'OG Title');
+  assert.equal(page.twitter_card, 'summary_large_image');
+  assert.equal(page.favicon_url, 'https://example.com/favicon.ico');
+  assert.equal(page.apple_touch_icon_url, 'https://example.com/apple.png');
+  assert.equal(page.link_internal_count, 1);
+    assert.equal(page.link_external_count, 2);
+  assert.equal(page.link_mailto_count, 1);
+  assert.equal(page.link_tel_count, 1);
+  assert.equal(page.link_sms_count, 1);
+  assert.equal(page.link_whatsapp_count, 1);
+  assert.equal(page.script_count, 2);
+  assert.equal(page.stylesheet_count, 1);
+  assert.equal(page.first_paragraph_text, 'First paragraph.');
+});


### PR DESCRIPTION
## Summary
- enrich page parser to output canonical URL, extended meta tags, OpenGraph/Twitter data, link and element counts, and more
- add unit test covering extended metadata extraction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adb02d2dd8832a89edb175d0019d34