### PR TITLE
feat: add headless HTML rendering

### DIFF
--- a/lib/fetch_html.js
+++ b/lib/fetch_html.js
@@ -1,9 +1,68 @@
 // lib/fetch_html.js
-// Fetch HTML with simple protocol guards and fallback to http/www.
+// Fetch HTML with simple protocol guards and fallback to http/www. When a page
+// appears to rely heavily on client-side rendering, fall back to a headless
+// browser (Playwright) to obtain the fully rendered markup.
+
+const cheerio = require('cheerio');
 
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
 
-async function fetchHtml(url, { timeoutMs = 12000 } = {}) {
+/** Heuristic to determine if a page likely requires JS rendering. */
+function needsRendering(rawHtml) {
+  try {
+    const $ = cheerio.load(rawHtml);
+    const body = $('body').clone();
+    body.find('script,style,noscript').remove();
+    const text = body.text().trim();
+    if (!text && body.children().length === 0) return true; // empty body
+
+    const bundleRe = /(bundle|webpack|main|chunk|app)\.\w+\.js/i;
+    const scripts = $('script[src]').map((_, el) => $(el).attr('src') || '').get();
+    return scripts.some(src => {
+      const name = (src.split('?')[0].split('/').pop() || '');
+      return bundleRe.test(name) || name.length > 30;
+    });
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch a page using a headless browser to render dynamic content. Tries
+ * Puppeteer first and falls back to Playwright if available. At least one of
+ * these libraries must be installed by the consuming project.
+ */
+async function fetchRenderedHtml(url, { timeoutMs = 20000 } = {}) {
+  // Attempt Puppeteer
+  try {
+    const puppeteer = require('puppeteer');
+    const browser = await puppeteer.launch({ headless: 'new' });
+    try {
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: 'networkidle0', timeout: timeoutMs });
+      return await page.content();
+    } finally {
+      await browser.close();
+    }
+  } catch (e1) {
+    // Fallback to Playwright if Puppeteer unavailable
+    try {
+      const { chromium } = require('playwright');
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        await page.goto(url, { waitUntil: 'networkidle', timeout: timeoutMs });
+        return await page.content();
+      } finally {
+        await browser.close();
+      }
+    } catch {
+      throw e1;
+    }
+  }
+}
+
+async function fetchHtml(url, { timeoutMs = 12000, headlessTimeoutMs = 20000 } = {}) {
   let pageUrl;
   try { pageUrl = new URL(url); } catch { throw new Error('Invalid URL'); }
   if (!ALLOWED_PROTOCOLS.has(pageUrl.protocol)) throw new Error('URL must use http/https');
@@ -49,11 +108,20 @@ async function fetchHtml(url, { timeoutMs = 12000 } = {}) {
       if (!resp) throw e1;
       if (success) pageUrl = new URL(success);
     }
+
     const html = await resp.text();
+    if (needsRendering(html)) {
+      try {
+        const rendered = await fetchRenderedHtml(pageUrl.toString(), { timeoutMs: headlessTimeoutMs });
+        return { html: rendered, url: pageUrl.toString() };
+      } catch {
+        // If headless fails, fall back to original HTML
+      }
+    }
     return { html, url: pageUrl.toString() };
   } finally {
     clearTimeout(timer);
   }
 }
 
-module.exports = { fetchHtml, ALLOWED_PROTOCOLS };
+module.exports = { fetchHtml, fetchRenderedHtml, ALLOWED_PROTOCOLS };

--- a/lib/fetch_html.js
+++ b/lib/fetch_html.js
@@ -14,39 +14,36 @@ function needsRendering(rawHtml) {
     const body = $('body').clone();
     body.find('script,style,noscript').remove();
     const text = body.text().trim();
-    if (!text && body.children().length === 0) return true; // empty body
+    const childCount = body.children().length;
+    if (!text && childCount === 0) return true; // empty body entirely
 
-    const bundleRe = /(bundle|webpack|main|chunk|app)\.\w+\.js/i;
-    const scripts = $('script[src]').map((_, el) => $(el).attr('src') || '').get();
-    return scripts.some(src => {
-      const name = (src.split('?')[0].split('/').pop() || '');
-      return bundleRe.test(name) || name.length > 30;
-    });
+    // Only treat pages with very little visible text as JS rendered.
+    if (text.length < 50) {
+      const bundleRe = /(bundle|webpack|main|chunk|app)\.\w+\.js/i;
+      const scripts = $('script[src]').map((_, el) => $(el).attr('src') || '').get();
+      if (scripts.some(src => {
+        const name = (src.split('?')[0].split('/').pop() || '');
+        return bundleRe.test(name) || name.length > 30;
+      })) {
+        return true;
+      }
+    }
   } catch {
-    return false;
+    // ignore parsing errors and assume no rendering needed
   }
+  return false;
 }
 
 /**
- * Fetch a page using a headless browser to render dynamic content. Tries
- * Puppeteer first and falls back to Playwright if available. At least one of
- * these libraries must be installed by the consuming project.
+ * Fetch a page using a headless browser to render dynamic content. Attempts
+ * Playwright (or playwright-core) first, then falls back to Puppeteer (or
+ * puppeteer-core). At least one of these libraries must be installed by the
+ * consuming project. If none are available the caller should handle the
+ * thrown error and fall back to non-rendered HTML.
  */
 async function fetchRenderedHtml(url, { timeoutMs = 20000 } = {}) {
-  // Attempt Puppeteer
-  try {
-    const puppeteer = require('puppeteer');
-    const browser = await puppeteer.launch({ headless: 'new' });
-    try {
-      const page = await browser.newPage();
-      await page.goto(url, { waitUntil: 'networkidle0', timeout: timeoutMs });
-      return await page.content();
-    } finally {
-      await browser.close();
-    }
-  } catch (e1) {
-    // Fallback to Playwright if Puppeteer unavailable
-    try {
+  const attempts = [
+    async () => {
       const { chromium } = require('playwright');
       const browser = await chromium.launch();
       try {
@@ -56,10 +53,51 @@ async function fetchRenderedHtml(url, { timeoutMs = 20000 } = {}) {
       } finally {
         await browser.close();
       }
-    } catch {
-      throw e1;
+    },
+    async () => {
+      const { chromium } = require('playwright-core');
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        await page.goto(url, { waitUntil: 'networkidle', timeout: timeoutMs });
+        return await page.content();
+      } finally {
+        await browser.close();
+      }
+    },
+    async () => {
+      const puppeteer = require('puppeteer');
+      const browser = await puppeteer.launch({ headless: 'new' });
+      try {
+        const page = await browser.newPage();
+        await page.goto(url, { waitUntil: 'networkidle0', timeout: timeoutMs });
+        return await page.content();
+      } finally {
+        await browser.close();
+      }
+    },
+    async () => {
+      const puppeteer = require('puppeteer-core');
+      const browser = await puppeteer.launch({ headless: 'new' });
+      try {
+        const page = await browser.newPage();
+        await page.goto(url, { waitUntil: 'networkidle0', timeout: timeoutMs });
+        return await page.content();
+      } finally {
+        await browser.close();
+      }
+    }
+  ];
+
+  let firstErr;
+  for (const attempt of attempts) {
+    try {
+      return await attempt();
+    } catch (err) {
+      if (!firstErr) firstErr = err;
     }
   }
+  throw firstErr || new Error('No headless browser available');
 }
 
 async function fetchHtml(url, { timeoutMs = 12000, headlessTimeoutMs = 20000 } = {}) {
@@ -124,4 +162,4 @@ async function fetchHtml(url, { timeoutMs = 12000, headlessTimeoutMs = 20000 } =
   }
 }
 
-module.exports = { fetchHtml, fetchRenderedHtml, ALLOWED_PROTOCOLS };
+module.exports = { fetchHtml, fetchRenderedHtml, ALLOWED_PROTOCOLS, _needsRendering: needsRendering };

--- a/test/fetch_html.test.js
+++ b/test/fetch_html.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { _needsRendering } = require('../lib/fetch_html');
+
+test('needsRendering flags empty bodies', () => {
+  const html = '<html><body></body></html>';
+  assert.strictEqual(_needsRendering(html), true);
+});
+
+test('needsRendering ignores content despite bundlers', () => {
+  const content = 'Hello world '.repeat(10); // >50 chars
+  const html = `<html><body><div>${content}</div><script src="/app.1234567890abcdef.js"></script></body></html>`;
+  assert.strictEqual(_needsRendering(html), false);
+});
+
+test('needsRendering flags minimal text with big bundles', () => {
+  const html = '<html><body><div>Hi</div><script src="/main.12345678901234567890.js"></script></body></html>';
+  assert.strictEqual(_needsRendering(html), true);
+});


### PR DESCRIPTION
## Summary
- detect empty bodies or heavy JS bundles and trigger headless rendering
- add `fetchRenderedHtml` using Puppeteer with Playwright fallback
- return rendered HTML so downstream parsing sees dynamic content

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/puppeteer-core)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8e174804832aa864783d2f2d06a1