### PR TITLE
Enhance parsing heuristics for services, projects, and contacts

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -34,38 +34,76 @@ function resolveUrl(u, base) {
 function parseServicePanels($, base) {
   const norm = (t) => (t || '').replace(/\s+/g, ' ').trim();
   const services = [];
-  $('.service-panel').each((_, el) => {
+  const svcSel = '.service-panel,[class*="service" i],[id*="service" i],[class*="offer" i],[class*="package" i],[class*="plan" i]';
+  const candidates = $(svcSel).filter((_, el) => !$(el).find(svcSel).length);
+  const seen = new Set();
+  candidates.each((_, el) => {
     if (services.length >= 3) return;
+    const key = $.html(el);
+    if (seen.has(key)) return;
+    seen.add(key);
     const $p = $(el);
     const svc = {};
     const img = $p.find('img').attr('src');
     if (img) svc.image_url = resolveUrl(img, base);
-    const price = norm($p.find('.price').first().text());
+    const price = norm(
+      $p
+        .find('[class*="price" i], [id*="price" i], [class*="cost" i], [id*="cost" i]')
+        .first()
+        .text()
+    );
     if (price) svc.price = price;
-    const priceNote = norm($p.find('.price-note').first().text());
+    const priceNote = norm(
+      $p
+        .find('[class*="note" i], [class*="desc" i], [class*="detail" i]')
+        .first()
+        .text()
+    );
     if (priceNote) svc.price_note = priceNote;
-    const cta = $p.find('.cta').first();
+    const cta = $p
+      .find('.cta, [class*="cta" i], [class*="button" i], a[href]')
+      .filter((_, a) => norm($(a).text()))
+      .first();
     if (cta.length) {
       const label = norm(cta.text());
       if (label) svc.cta_label = label;
       const href = cta.attr('href');
       if (href) svc.cta_link = resolveUrl(href, base);
     }
-    const modes = norm($p.find('.delivery-modes').first().text());
+    const modes = norm(
+      $p
+        .find('[class*="delivery" i], [class*="mode" i]')
+        .first()
+        .text()
+    );
     if (modes) svc.delivery_modes = modes.split(/[,|]/).map(norm).filter(Boolean).join(',');
-    const inclusions = $p.find('.inclusions li').map((_, li) => norm($(li).text())).get().filter(Boolean);
+    const inclusions = $p
+      .find('[class*="inclusion" i] li, .inclusions li')
+      .map((_, li) => norm($(li).text()))
+      .get()
+      .filter(Boolean);
     if (inclusions[0]) svc.inclusion_1 = inclusions[0];
     if (inclusions[1]) svc.inclusion_2 = inclusions[1];
     if (inclusions[2]) svc.inclusion_3 = inclusions[2];
     const video = $p.find('video').attr('src');
     if (video) svc.video_url = resolveUrl(video, base);
     let tags = [];
-    tags = tags.concat($p.find('.tags li').map((_, li) => norm($(li).text())).get());
-    const dataTags = ($p.attr('data-tags') || '').split(',').map(norm).filter(Boolean);
+    tags = tags.concat(
+      $p
+        .find('.tags li, [class*="tag" i] li')
+        .map((_, li) => norm($(li).text()))
+        .get()
+    );
+    const dataTags = ($p.attr('data-tags') || '')
+      .split(',')
+      .map(norm)
+      .filter(Boolean);
     tags = Array.from(new Set([...tags, ...dataTags]));
     if (tags.length) {
       svc.tags = tags.join(',');
-      const panelTag = tags.find(t => /^featured (service|project|product)$/i.test(t));
+      const panelTag = tags.find((t) =>
+        /^featured (service|project|product)$/i.test(t)
+      );
       if (panelTag) svc.panel_tag = panelTag.toLowerCase();
     }
     services.push(svc);
@@ -76,14 +114,25 @@ function parseServicePanels($, base) {
 function parseProjects($, base) {
   const norm = (t) => (t || '').replace(/\s+/g, ' ').trim();
   const projects = [];
-  $('.project').each((_, el) => {
+  const projSel = '.project,[class*="project" i],[id*="project" i],[class*="portfolio" i],[class*="work" i],[class*="case" i]';
+  const candidates = $(projSel).filter((_, el) => !$(el).find(projSel).length);
+  const seen = new Set();
+  candidates.each((_, el) => {
+    const key = $.html(el);
+    if (seen.has(key)) return;
+    seen.add(key);
     const $p = $(el);
     const proj = {};
     const img = $p.find('img').attr('src');
     if (img) proj.image_url = resolveUrl(img, base);
-    const title = norm($p.find('.title, h3, h2').first().text());
+    const title = norm(
+      $p
+        .find('[class*="title" i], h3, h2, h4')
+        .first()
+        .text()
+    );
     if (title) proj.title = title;
-    const href = $p.find('a').attr('href');
+    const href = $p.find('a[href]').first().attr('href');
     if (href) proj.cta_link = resolveUrl(href, base);
     projects.push(proj);
   });
@@ -342,11 +391,19 @@ async function parse(html, pageUrl) {
   });
 
   $('form').each((_, el) => {
-    const action = $(el).attr('action') || '';
-    const idClass = ($(el).attr('id') || '') + ' ' + ($(el).attr('class') || '');
-    if (/(contact|enquiry|inquiry)/i.test(action) || /(contact|enquiry|inquiry)/i.test(idClass)) {
+    const $el = $(el);
+    const action = $el.attr('action') || '';
+    const idClass = ($el.attr('id') || '') + ' ' + ($el.attr('class') || '');
+    const text = norm($el.text());
+    const placeholders = $el
+      .find('input,textarea')
+      .map((_, i) => $(i).attr('placeholder') || '')
+      .get()
+      .join(' ');
+    const haystack = `${action} ${idClass} ${text} ${placeholders}`;
+    if (/(contact|enquiry|inquiry|quote|message)/i.test(haystack)) {
       try {
-        const abs = new URL(action, baseForResolve).toString();
+        const abs = new URL(action || pageUrl, baseForResolve).toString();
         if (isHttp(abs)) contact_forms.push(abs);
       } catch {}
     }
@@ -478,18 +535,46 @@ async function parse(html, pageUrl) {
   const projects = parseProjects($, baseForResolve);
 
   // Owner name/title/headshot
+  const ownerKeywords = ['owner', 'founder', 'director', 'principal', 'manager'];
   let ownerName =
     $('.owner .name').first().text().trim() ||
     $('[data-owner-name]').first().text().trim() ||
     null;
-  const ownerTitle =
+  let ownerTitle =
     $('.owner .title').first().text().trim() ||
     $('[data-owner-title]').first().text().trim() ||
     null;
-  const headshotUrl =
-    $('.owner img').first().attr('src') ||
-    $('img[alt*="headshot" i]').first().attr('src') ||
+  let headshotUrl =
+    resolveUrl($('.owner img').first().attr('src'), baseForResolve) ||
+    resolveUrl($('img[alt*="headshot" i]').first().attr('src'), baseForResolve) ||
     null;
+
+  if (!ownerName || !ownerTitle || !headshotUrl) {
+    for (const kw of ownerKeywords) {
+      const $sec = $(`[class*='${kw}' i], [id*='${kw}' i]`).first();
+      if (!$sec.length) continue;
+      if (!ownerName) {
+        ownerName = norm(
+          $sec
+            .find("[class*='name' i], [id*='name' i], h1, h2, h3, h4, h5, h6")
+            .first()
+            .text()
+        ) || ownerName;
+      }
+      if (!ownerTitle) {
+        ownerTitle = norm(
+          $sec
+            .find("[class*='title' i], [class*='role' i], [class*='position' i]")
+            .first()
+            .text()
+        ) || ownerTitle;
+      }
+      if (!headshotUrl) {
+        headshotUrl = resolveUrl($sec.find('img').first().attr('src'), baseForResolve) || headshotUrl;
+      }
+      if (ownerName && ownerTitle && headshotUrl) break;
+    }
+  }
   let identityBusinessName = null;
   let identityLogoUrl = null;
 

--- a/test/fixtures/alt_patterns.html
+++ b/test/fixtures/alt_patterns.html
@@ -1,0 +1,32 @@
+<html>
+  <body>
+    <section class="offers">
+      <div class="offer-card">
+        <img src="svc1.png" />
+        <div class="cost">$50</div>
+        <a class="button" href="/buy1">Buy 1</a>
+      </div>
+      <div class="service-item">
+        <img src="svc2.png" />
+        <div class="price-tag">$80</div>
+        <a href="/buy2">Buy 2</a>
+      </div>
+    </section>
+    <section class="portfolio">
+      <article class="portfolio-item">
+        <img src="proj1.png" />
+        <h3>Project Alpha</h3>
+        <a href="/proj1">View</a>
+      </article>
+    </section>
+    <div class="founder-card">
+      <img src="headshot.jpg" />
+      <span class="founder-name">Alice Owner</span>
+      <span class="founder-role">Founder</span>
+    </div>
+    <form action="/submit">
+      <h2>Contact Us</h2>
+      <input type="text" placeholder="Your name" />
+    </form>
+  </body>
+</html>

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -84,6 +84,20 @@ test('parse enriches identity fields from Person JSON-LD', async () => {
   assert.ok(page.social.find(s => s.platform === 'instagram' && s.url === 'https://instagram.com/johnsmith'));
 });
 
+test('parse detects alternate panels, projects, owner and contact form', async () => {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures/alt_patterns.html'), 'utf8');
+  const page = await parse(html, 'http://example.com');
+  assert.equal(page.service_panels.length, 2);
+  assert.equal(page.service_panels[0].price, '$50');
+  assert.equal(page.service_panels[1].price, '$80');
+  assert.equal(page.projects.length, 1);
+  assert.equal(page.projects[0].title, 'Project Alpha');
+  assert.equal(page.identity_owner_name, 'Alice Owner');
+  assert.equal(page.identity_role_title, 'Founder');
+  assert.equal(page.identity_headshot_url, 'http://example.com/headshot.jpg');
+  assert.deepEqual(page.contact_form_links, ['http://example.com/submit']);
+});
+
 test('parse extracts extended meta fields and counts', async () => {
   const restore = mockFetch({ 'https://example.com/style.css': { body: '' } });
   const html = fs.readFileSync(path.join(__dirname, 'fixtures/meta.html'), 'utf8');


### PR DESCRIPTION
## Summary
- expand service and project panel discovery using keyword-based selectors and flexible field extraction
- broaden owner/contact heuristics with keyword search and form text inspection
- add fixture and tests covering alternate panel and project structures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8e18a9f0832a94025fff6f86c050