### PR TITLE
fix: whitelist missing service field

### DIFF
--- a/config/field_intent_map.yaml
+++ b/config/field_intent_map.yaml
@@ -433,7 +433,7 @@ service_3_inclusion_2:
   fallback: true
   constraints: *_inclusion_constraints
 
-service_3_Inclusion_3:
+service_3_inclusion_3:
   priority: required
   tools: [site_scraper]
   fallback: true

--- a/lib/acf_contract.js
+++ b/lib/acf_contract.js
@@ -9,7 +9,8 @@ const YAML = require('yaml');
 const aliases = {
   trust_award_link: 'trsut_award_link',
   trsut_award_link: 'trust_award_link',
-  service_3_inclusion_3: 'service_3_Inclusion_3'
+  service_3_inclusion_3: 'service_3_Inclusion_3',
+  service_3_Inclusion_3: 'service_3_inclusion_3'
 };
 
 function getAllowKeys() {


### PR DESCRIPTION
## Summary
- whitelist `service_3_inclusion_3` in field intent map
- add reciprocal alias for `service_3_inclusion_3` in ACF contract helper

## Testing
- `npm test`
- `npm run audit:intent`
- `node api/build.js` on `https://poolboysco.com.au`

------
https://chatgpt.com/codex/tasks/task_e_68ae8e199f10832a918a72d22f7be54f