### PR TITLE
Enable LLM strategies for description fields

### DIFF
--- a/config/field_intent_map.yaml
+++ b/config/field_intent_map.yaml
@@ -202,8 +202,12 @@ service_1_price_note:
 
 service_1_description:
   priority: required
+  strategy: det_then_llm
   tools: [site_scraper]
   fallback: false
+  llm:
+    validate:
+      min_words: 30
   constraints:
     min_words: 30
 
@@ -292,8 +296,12 @@ service_2_price_note:
 
 service_2_description:
   priority: required
+  strategy: det_then_llm
   tools: [site_scraper]
   fallback: false
+  llm:
+    validate:
+      min_words: 30
   constraints:
     min_words: 30
 
@@ -382,8 +390,12 @@ service_3_price_note:
 
 service_3_description:
   priority: required
+  strategy: det_then_llm
   tools: [site_scraper]
   fallback: false
+  llm:
+    validate:
+      min_words: 30
   constraints:
     min_words: 30
 
@@ -657,8 +669,13 @@ social_links_youtube:
 
 business_description:
   priority: recommended
+  strategy: det_then_llm
   tools: [site_scraper]
   fallback: false
+  llm:
+    validate:
+      min_words: 20
+      max_len: 240
   constraints:
     min_words: 20
     max_length: 240
@@ -682,8 +699,12 @@ testimonial_location:
 
 testimonial_quote:
   priority: required_if_testimonial
+  strategy: det_then_llm
   tools: [site_scraper, gmb_lookup]
   fallback: false
+  llm:
+    validate:
+      min_words: 20
   constraints:
     min_words: 20
     reviewer_required: true

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -322,6 +322,14 @@ function passesValidation(val, rule = {}) {
   if (v.url && !/^https?:\/\//i.test(s)) return false;
   if (v.min_len && s.length < v.min_len) return false;
   if (v.max_len && s.length > v.max_len) return false;
+  if (v.min_words) {
+    const wc = s.split(/\s+/).filter(Boolean).length;
+    if (wc < v.min_words) return false;
+  }
+  if (v.max_words) {
+    const wc = s.split(/\s+/).filter(Boolean).length;
+    if (wc > v.max_words) return false;
+  }
   return true;
 }
 
@@ -417,3 +425,4 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
 };
 
 exports.helpers = helpers;
+exports.passesValidation = passesValidation;

--- a/lib/llm_resolver.js
+++ b/lib/llm_resolver.js
@@ -29,13 +29,28 @@ async function callOpenAI(payload) {
 
 const batchCache = new Map();
 
+function defaultPrompt(k = '') {
+  if (k === 'business_description') {
+    return 'Write a concise 20+ word description of the business based on the provided content.';
+  }
+  if (k === 'testimonial_quote') {
+    return 'Produce a 20+ word positive testimonial quote based on the provided reviews or content.';
+  }
+  const m = k.match(/^service_(\d+)_description$/);
+  if (m) {
+    return `Write a 30+ word description for service ${m[1]} using the provided site content.`;
+  }
+  return '';
+}
+
 module.exports.resolveField = async function resolveField(
   key,
   rule = {},
-  { raw = {}, tradecard = {}, fields = {} } = {}
+  { raw = {}, tradecard = {}, fields = {} } = {},
 ) {
   const llmRule = rule.llm || {};
-  const batchKey = llmRule.batch ? llmRule.prompt || key : null;
+  const prompt = llmRule.prompt || defaultPrompt(key);
+  const batchKey = llmRule.batch ? prompt || key : null;
   if (batchKey && batchCache.has(batchKey)) {
     const cached = batchCache.get(batchKey);
     return cached[key] || '';
@@ -58,7 +73,7 @@ module.exports.resolveField = async function resolveField(
       name: tradecard?.business?.name || '',
       website: tradecard?.contacts?.website || ''
     },
-    instructions: llmRule.prompt || ''
+    instructions: prompt || ''
   };
 
   if (llmRule.batch) {
@@ -87,5 +102,14 @@ module.exports.resolveField = async function resolveField(
   if (s && v.url && !/^https?:\/\//i.test(s)) s = '';
   if (s && v.min_len && s.length < v.min_len) s = '';
   if (s && v.max_len && s.length > v.max_len) s = s.slice(0, v.max_len);
+  if (s && v.min_words) {
+    const wc = s.trim().split(/\s+/).filter(Boolean).length;
+    if (wc < v.min_words) s = '';
+  }
+  if (s && v.max_words) {
+    const parts = s.trim().split(/\s+/).filter(Boolean);
+    if (parts.length > v.max_words) s = parts.slice(0, v.max_words).join(' ');
+  }
   return s;
 };
+

--- a/test/llm.prompts.test.js
+++ b/test/llm.prompts.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('applyIntent uses default LLM prompts for description fields', async () => {
+  const raw = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/apply-intent.raw.json'), 'utf8'));
+
+  const origKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'test-key';
+
+  const calls = [];
+  const LONG_TEXT = Array(40).fill('word').join(' ');
+  const origFetch = global.fetch;
+  global.fetch = async (url, opts) => {
+    const payload = JSON.parse(JSON.parse(opts.body).messages[1].content);
+    calls.push(payload.instructions);
+    return { json: async () => ({ choices: [{ message: { content: LONG_TEXT } }] }) };
+  };
+
+  const { applyIntent } = require('../lib/intent');
+  const { fields } = await applyIntent({}, { raw });
+
+  assert.equal(fields.business_description, LONG_TEXT);
+  assert.equal(fields.service_1_description, LONG_TEXT);
+  assert.ok(calls.some((i) => /business/i.test(i)));
+  assert.ok(calls.some((i) => /service 1/i.test(i)));
+
+  global.fetch = origFetch;
+  process.env.OPENAI_API_KEY = origKey;
+});
+

--- a/test/passesValidation.test.js
+++ b/test/passesValidation.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { passesValidation } = require('../lib/intent');
+
+test('passesValidation enforces min_words', () => {
+  const rule = { llm: { validate: { min_words: 5 } } };
+  assert.strictEqual(passesValidation('one two three', rule), false);
+  assert.strictEqual(passesValidation('one two three four five', rule), true);
+});
+


### PR DESCRIPTION
## Summary
- Enable det-then-LLM resolution and validation for service descriptions, business description, and testimonial quotes
- Provide default prompt templates and word-count checks in the LLM resolver
- Support min word validation in intent handling and add unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae8e1a7e2c832a933cf8a6b695015d