### PR TITLE
Expand regex patterns for phone numbers and ABNs

### DIFF
--- a/config/field_intent_map.yaml
+++ b/config/field_intent_map.yaml
@@ -47,6 +47,8 @@ identity_abn:
   priority: recommended
   tools: [site_scraper]
   fallback: false
+  constraints:
+    regex: "^(?:\\d[\\s-]?){11}$"
 
 identity_insured:
   priority: optional
@@ -81,7 +83,7 @@ identity_phone:
   fallback: false
   constraints:
     format: spaced_human_readable
-    regex: "^\\+?[0-9 ]+$"
+    regex: "^\\+?[0-9 ()-]+$"
 
 identity_website:
   priority: required

--- a/lib/detExtractors.js
+++ b/lib/detExtractors.js
@@ -1,7 +1,9 @@
 const EMAIL_RX = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i;
-const PHONE_RX = /^\+?[0-9 ][0-9 \-]{7,19}$/;
+// Allow international formats with spaces, dashes or parentheses
+const PHONE_RX = /^\+?\(?[0-9][0-9\s\-()]{7,19}$/;
 const URL_RX = /^https?:\/\//i;
-const ABN_RX = /(ABN|A\.?B\.?N\.?)[^\d]*((\d\s*){11})/i;
+// Match 11 digits for ABN allowing spaces or dashes and optional "ABN" prefix
+const ABN_RX = /(ABN|A\.?B\.?N\.?)?[^0-9]*((?:\d[\s-]*){11})/i;
 
 function norm(s=''){return String(s||'').trim();}
 function normUrl(u=''){const s=norm(u);if(!s||/^data:/i.test(s))return'';if(/^https?:\/\//i.test(s))return s;return s.startsWith('//')?'https:'+s:'';}
@@ -44,11 +46,13 @@ function getEmail(raw = {}) {
 }
 
 function getPhone(raw = {}) {
-  const scan = /\+?[0-9][0-9 \-]{7,19}/;
+  // Scan for numbers allowing international characters and parentheses
+  const scan = /\+?\(?[0-9][0-9\s\-()]{7,19}/;
   const normP = v => {
     v = v.replace(/[^0-9+]+/g, ' ').trim().replace(/\s+/g, ' ');
     let d = v.replace(/\s+/g, '');
     if (d.startsWith('+')) return d;
+    if (d.startsWith('00')) return '+' + d.slice(2);
     if (d.startsWith('0')) return '+61' + d.slice(1);
     if (!d.startsWith('61')) return '+61' + d;
     return '+' + d;
@@ -149,7 +153,7 @@ function getABN(raw={}){
   for(const a of raw.anchors||[]){ texts.push(norm(a.text),norm(a.href)); }
   for(const v of Object.values(raw.meta||{})) texts.push(norm(v));
   const m=texts.join(' ').match(ABN_RX);
-  return m?{ value:m[2].replace(/\s+/g,''), source:'regex' }:{ value:'', source:'' };
+  return m?{ value:m[2].replace(/[\s-]+/g,''), source:'regex' }:{ value:'', source:'' };
 }
 
 const SOCIAL_DOMAINS = {

--- a/test/intent.fuzzy.test.js
+++ b/test/intent.fuzzy.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { helpers } = require('../lib/intent');
+const det = require('../lib/detExtractors');
 
 test('detResolve fuzzy matches close raw keys', () => {
   const raw = { identity_ownername: 'Jane Doe' };
@@ -18,4 +19,12 @@ test('detResolve handles small typos in keys', () => {
   const raw = { identity_owner_nmae: 'Jane Doe' };
   const val = helpers.detResolve('identity_owner_name', {}, { raw });
   assert.equal(val, 'Jane Doe');
+});
+
+test('PHONE_RX accepts international formats', () => {
+  assert(det.PHONE_RX.test('+1 (555) 123-4567'));
+});
+
+test('ABN_RX accepts spaces and dashes', () => {
+  assert(det.ABN_RX.test('ABN 12-345-678-901'));
 });


### PR DESCRIPTION
## Summary
- allow spaces, dashes, and parentheses in phone and ABN detection
- handle international phone formats including 00 prefix
- broaden field constraints and add tests for new formats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8e1b9978832ab3c3120f6029b82b