### PR TITLE
chore: restrict accept workflow to manual runs

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -1,6 +1,6 @@
+# Manual run only; requires a running server (BASE/TARGET).
 name: Acceptance
 on:
-  pull_request:
   workflow_dispatch:
 concurrency:
   group: accept-${{ github.ref }}


### PR DESCRIPTION
## Summary
- run accept workflow manually only, requiring BASE and TARGET server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9d8f16c8832aafc331f33b33f029