### PR TITLE
feat: log unresolved extraction misses

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -1,5 +1,6 @@
 "use strict";
 const { expandKeys, ruleFor, categoryOf } = require('./intent_map');
+const { logMiss } = require('../scripts/log-misses');
 
 const ORDER = ['identity', 'socials', 'services', 'content', 'testimonials', 'trust_theme'];
 
@@ -52,6 +53,9 @@ async function runExecutor({ map = {}, allowSet = new Set(), raw = {}, tradecard
     const entry = { key, strategy: used, ok };
     if (!ok && reason) entry.reason = reason;
     audit.push(entry);
+    if (!ok) {
+      logMiss({ key, snippet: raw[key], rule, suggestion: '' });
+    }
   }
 
   return { fields, audit };

--- a/lib/intent.js
+++ b/lib/intent.js
@@ -14,6 +14,7 @@ const {
 const { proposeForUnresolved } = require('./llmFullFrame');
 const { readYaml } = require('./config');
 const det = require('./detExtractors');
+const { logMiss } = require('../scripts/log-misses');
 
 const resolveConfig = readYaml('config/resolve.yaml');
 
@@ -398,27 +399,43 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
   deriveFields(fields, { tradecard_url: tradecard?.slug });
   Object.assign(fields, identity, social);
 
+  let proposals = {};
   if (!opts.noLLM) {
     const allowKeys = Array.from(allowSet);
     const unresolvedKeys = allowKeys.filter((k) => (!fields[k] || fields[k] === '') && map[k]);
     trace.push({ stage: 'llm_input', key_count: allowKeys.length, has_raw: !!raw });
-    let proposals = {};
     const accepted = [];
     const rejected = [];
     if (unresolvedKeys.length) {
       ({ proposals = {} } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, intentMap: map, resolveConfig, fixture: tradecard?.slug, fullRaw: fullFrame }));
       for (const [k, v] of Object.entries(proposals)) {
         const rule = imap.ruleFor(map, k);
-        if (!allowSet.has(k)) { rejected.push({ key: k, reason: 'not_allowed' }); continue; }
-        if (fields[k] && passesValidation(fields[k], rule)) { rejected.push({ key: k, reason: 'already_set' }); continue; }
-        if (passesValidation(v, rule)) { fields[k] = String(v); accepted.push(k); }
-        else { rejected.push({ key: k, reason: 'failed-validate' }); }
+        if (!allowSet.has(k)) {
+          rejected.push({ key: k, reason: 'not_allowed' });
+          logMiss({ key: k, snippet: raw[k], rule, suggestion: v });
+          continue;
+        }
+        if (fields[k] && passesValidation(fields[k], rule)) {
+          rejected.push({ key: k, reason: 'already_set' });
+          continue;
+        }
+        if (passesValidation(v, rule)) {
+          fields[k] = String(v);
+          accepted.push(k);
+        } else {
+          rejected.push({ key: k, reason: 'failed-validate' });
+          logMiss({ key: k, snippet: raw[k], rule, suggestion: v });
+        }
       }
     }
     trace.push({ stage: 'llm_merge', proposed: Object.keys(proposals).length, accepted, rejected });
   }
   const remaining = Array.from(allowSet).filter(k => !fields[k]);
   trace.push({ stage: 'unresolved', remaining });
+  for (const k of remaining) {
+    const rule = imap.ruleFor(map, k);
+    logMiss({ key: k, snippet: raw[k], rule, suggestion: proposals[k] });
+  }
 
   trace.push({ stage: 'intent_coverage', before: Object.keys(map).length, after: Object.keys(fields).length, sample_sent: Object.keys(fields).slice(0, 10) });
   return { fields, sent_keys: Object.keys(fields), audit, trace };

--- a/scripts/log-misses.js
+++ b/scripts/log-misses.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const dest = process.env.MISS_LOG;
+const ext = dest ? path.extname(dest).toLowerCase() : '.jsonl';
+
+function serialize(entry = {}) {
+  if (ext === '.csv') {
+    const cols = ['key', 'snippet', 'rule', 'suggestion'];
+    return (
+      cols
+        .map((k) => {
+          let v = entry[k];
+          if (v === undefined || v === null) v = '';
+          if (typeof v === 'object') v = JSON.stringify(v);
+          v = String(v).replace(/"/g, '""');
+          return `"${v}"`;
+        })
+        .join(',') + '\n'
+    );
+  }
+  return JSON.stringify(entry) + '\n';
+}
+
+function logMiss(entry = {}) {
+  if (!dest) return;
+  try {
+    fs.appendFileSync(dest, serialize(entry));
+  } catch {}
+}
+
+module.exports = { logMiss };


### PR DESCRIPTION
## Summary
- add log-misses helper to append unresolved field details to JSONL/CSV
- capture unresolved and validation failures in executor and intent flows
- extend test mock helper to intercept fs writes alongside fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeda5884c8832ab080f017ac1dc6fc