### PR TITLE
feat: add self verification to LLM proposals

### DIFF
--- a/lib/llmFullFrame.js
+++ b/lib/llmFullFrame.js
@@ -1,5 +1,15 @@
 "use strict";
 
+/**
+ * LLM interaction helpers with self-verification.
+ *
+ * `proposeForUnresolved` performs a two-pass strategy where the first
+ * prompt proposes answers for requested fields and a second prompt verifies
+ * those answers.  It returns the verified results along with any keys where
+ * the verification disagreed with the initial proposal so callers can handle
+ * mismatches explicitly.
+ */
+
 async function callLLM(payload) {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) return "{}";
@@ -94,7 +104,32 @@ async function proposeForUnresolved({
       proposals[k] = v === null || v === undefined ? "" : String(v);
     }
   }
-  return { proposals, stats: { approx_tokens, approx_bytes } };
+
+  // Second pass: verification prompt compares original proposals with RAW.
+  const verifyPrompt = {
+    fixture,
+    RAW: safeRaw,
+    ORIGINAL: proposals,
+    INSTRUCTION: "Verify each ORIGINAL value against RAW and return corrected JSON for the same keys. Use ORIGINAL value if already correct."
+  };
+  const verifyRes = await callLLM(verifyPrompt);
+  let verifiedObj;
+  try { verifiedObj = JSON.parse(verifyRes); } catch { verifiedObj = {}; }
+  const verified = {};
+  const discrepancies = [];
+  for (const k of Object.keys(proposals)) {
+    let v = verifiedObj[k];
+    if (v === undefined) v = proposals[k];
+    const str = v === null || v === undefined ? "" : String(v);
+    verified[k] = str;
+    if (str !== proposals[k]) discrepancies.push(k);
+  }
+
+  return {
+    proposals: verified,
+    discrepancies,
+    stats: { approx_tokens, approx_bytes }
+  };
 }
 
 module.exports = { proposeForUnresolved };

--- a/test/llmFullFrame.test.js
+++ b/test/llmFullFrame.test.js
@@ -6,18 +6,24 @@ test('uses full raw and returns allowed proposals', async () => {
   const raw = { anchors: Array.from({ length: 60 }, (_, i) => ({ href: String(i) })) };
   const allowKeys = ['foo', 'baz'];
   const unresolvedKeys = ['foo'];
-  let sent;
+  let sentFirst;
+  let call = 0;
   const originalFetch = global.fetch;
   const originalKey = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = 'test';
   global.fetch = async (url, opts) => {
+    call++;
     const body = JSON.parse(opts.body);
-    sent = JSON.parse(body.messages[1].content);
-    return { json: async () => ({ choices: [{ message: { content: '{"foo":"bar","baz":"qux","x":"y"}' } }] }) };
+    const payload = JSON.parse(body.messages[1].content);
+    if (call === 1) sentFirst = payload;
+    return {
+      json: async () => ({ choices: [{ message: { content: '{"foo":"bar","baz":"qux","x":"y"}' } }] })
+    };
   };
-  const { proposals } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, maxTokens: 1e6 });
+  const { proposals, discrepancies } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, maxTokens: 1e6 });
   assert.deepEqual(proposals, { foo: 'bar', baz: 'qux' });
-  assert.equal(sent.RAW.anchors.length, 60);
+  assert.deepEqual(discrepancies, []);
+  assert.equal(sentFirst.RAW.anchors.length, 60);
   global.fetch = originalFetch;
   process.env.OPENAI_API_KEY = originalKey;
 });
@@ -26,17 +32,47 @@ test('compacts raw when prompt too large', async () => {
   const raw = { anchors: Array.from({ length: 60 }, (_, i) => ({ href: String(i) })) };
   const allowKeys = ['foo'];
   const unresolvedKeys = ['foo'];
-  let sent;
+  let sentFirst;
+  let call = 0;
   const originalFetch = global.fetch;
   const originalKey = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = 'test';
   global.fetch = async (url, opts) => {
+    call++;
     const body = JSON.parse(opts.body);
-    sent = JSON.parse(body.messages[1].content);
+    const payload = JSON.parse(body.messages[1].content);
+    if (call === 1) sentFirst = payload;
     return { json: async () => ({ choices: [{ message: { content: '{"foo":"bar"}' } }] }) };
   };
   await proposeForUnresolved({ raw, allowKeys, unresolvedKeys, maxTokens: 1 });
-  assert.equal(sent.RAW.anchors.length, 50);
+  assert.equal(sentFirst.RAW.anchors.length, 50);
+  global.fetch = originalFetch;
+  process.env.OPENAI_API_KEY = originalKey;
+});
+
+test('second pass can correct an initial mistake', async () => {
+  const raw = {};
+  const allowKeys = ['foo'];
+  const unresolvedKeys = ['foo'];
+  let sentSecond;
+  let call = 0;
+  const originalFetch = global.fetch;
+  const originalKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'test';
+  global.fetch = async (url, opts) => {
+    call++;
+    const body = JSON.parse(opts.body);
+    const payload = JSON.parse(body.messages[1].content);
+    if (call === 2) sentSecond = payload;
+    if (call === 1) {
+      return { json: async () => ({ choices: [{ message: { content: '{"foo":"wrong"}' } }] }) };
+    }
+    return { json: async () => ({ choices: [{ message: { content: '{"foo":"right"}' } }] }) };
+  };
+  const { proposals, discrepancies } = await proposeForUnresolved({ raw, allowKeys, unresolvedKeys });
+  assert.deepEqual(proposals, { foo: 'right' });
+  assert.deepEqual(discrepancies, ['foo']);
+  assert.equal(sentSecond.ORIGINAL.foo, 'wrong');
   global.fetch = originalFetch;
   process.env.OPENAI_API_KEY = originalKey;
 });


### PR DESCRIPTION
## Summary
- perform a second verification pass in `llmFullFrame` and surface discrepancies
- expand tests for verification and correction scenarios
- document the self-verification flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeda57f338832a930b97a9ce00da03