### PR TITLE
feat: enhance LLM resolver with context and confidence

### DIFF
--- a/lib/llm_resolver.js
+++ b/lib/llm_resolver.js
@@ -2,7 +2,7 @@
 
 async function callOpenAI(payload) {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) return '';
+  if (!apiKey) return '{}';
   try {
     const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -13,17 +13,17 @@ async function callOpenAI(payload) {
       body: JSON.stringify({
         model: 'gpt-4o-mini',
         temperature: 0,
-        response_format: { type: 'text' },
+        response_format: { type: 'json_object' },
         messages: [
-          { role: 'system', content: 'Return ONLY the value as plain text. No extra words.' },
+          { role: 'system', content: 'Return JSON {value:string,confidence:number} for requested fields.' },
           { role: 'user', content: JSON.stringify(payload) }
         ]
       })
     });
     const data = await res.json().catch(() => ({}));
-    return data?.choices?.[0]?.message?.content || '';
+    return data?.choices?.[0]?.message?.content || '{}';
   } catch {
-    return '';
+    return '{}';
   }
 }
 
@@ -31,22 +31,22 @@ const batchCache = new Map();
 
 function defaultPrompt(k = '') {
   if (k === 'business_description') {
-    return 'Write a concise 20+ word description of the business based on the provided content.';
+    return 'Write a concise 20+ word description of the business based on the provided content. Return JSON {value:string,confidence:number}.';
   }
   if (k === 'testimonial_quote') {
-    return 'Produce a 20+ word positive testimonial quote based on the provided reviews or content.';
+    return 'Produce a 20+ word positive testimonial quote based on the provided reviews or content. Return JSON {value:string,confidence:number}.';
   }
   const m = k.match(/^service_(\d+)_description$/);
   if (m) {
-    return `Write a 30+ word description for service ${m[1]} using the provided site content.`;
+    return `Write a 30+ word description for service ${m[1]} using the provided site content. Return JSON {value:string,confidence:number}.`;
   }
-  return '';
+  return 'Return JSON {value:string,confidence:number}.';
 }
 
 module.exports.resolveField = async function resolveField(
   key,
   rule = {},
-  { raw = {}, tradecard = {}, fields = {} } = {},
+  { raw = {}, tradecard = {}, fields = {}, unresolved = [], snippet = '' } = {},
 ) {
   const llmRule = rule.llm || {};
   const prompt = llmRule.prompt || defaultPrompt(key);
@@ -57,6 +57,8 @@ module.exports.resolveField = async function resolveField(
   }
 
   const payload = {
+    unresolved_fields: Array.isArray(unresolved) ? unresolved : [],
+    context_snippet: snippet,
     links: (raw.anchors || []).slice(0, 50).map((a) => ({ href: a.href || '', text: a.text || '' })),
     headings: (raw.headings || []).slice(0, 25).map((h) => h.text || h),
     images: (raw.images || []).slice(0, 30).map((i) => ({ src: i.src || '', alt: i.alt || '' })),
@@ -82,18 +84,36 @@ module.exports.resolveField = async function resolveField(
   }
 
   let rawRes = (await callOpenAI(payload)).trim();
+  let data;
   if (llmRule.batch) {
     let obj;
     try {
       obj = JSON.parse(rawRes);
     } catch {
-      obj = { [key]: rawRes };
+      obj = {};
     }
     batchCache.set(batchKey, obj);
-    rawRes = obj[key] || '';
+    data = obj[key];
+  } else {
+    try {
+      data = JSON.parse(rawRes);
+    } catch {
+      data = rawRes;
+    }
   }
 
-  let s = rawRes;
+  let s = '';
+  let confidence = 1;
+  if (data && typeof data === 'object') {
+    s = typeof data.value === 'string' ? data.value : '';
+    confidence = Number.isFinite(data.confidence) ? Number(data.confidence) : 1;
+  } else {
+    s = String(data || '');
+  }
+
+  const threshold = llmRule.confidence_threshold ?? 0.7;
+  if (confidence < threshold) s = '';
+
   const v = llmRule.validate || {};
   if (s && v.regex) {
     const rx = new RegExp(v.regex.replace(/^\/|\/$/g, ''), 'i');


### PR DESCRIPTION
## Summary
- extend LLM resolver to accept unresolved field lists and optional context snippet
- ask model for structured JSON responses with value and confidence
- reject low-confidence suggestions and add tests for structured responses

## Testing
- `npm test test/llm.prompts.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeda55ee58832aa5af4486ee30cbfa