### PR TITLE
Refactor resolve to orchestrate passes with coverage tracking

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -307,6 +307,71 @@ function resolveIdentity(parsed = {}) {
   return out;
 }
 
+function normalizePhone(p = '') {
+  let digits = String(p).replace(/[^0-9]/g, '');
+  if (digits.startsWith('0')) digits = '61' + digits.slice(1);
+  if (!digits.startsWith('61')) digits = '61' + digits;
+  return '+' + digits;
+}
+
+function metadataPass(raw = {}) {
+  const out = {};
+  if (raw.identity_owner_name) out.identity_owner_name = String(raw.identity_owner_name).trim();
+  if (raw.meta?.canonical) out.identity_website_url = raw.meta.canonical;
+  if (raw.meta?.['og:image']) out.identity_logo_url = raw.meta['og:image'];
+  return out;
+}
+
+function entityPass(raw = {}) {
+  const out = {};
+  for (const a of raw.anchors || []) {
+    const href = a.href || '';
+    if (!out.identity_email && href.startsWith('mailto:')) {
+      out.identity_email = href.slice(7).trim().toLowerCase();
+    }
+    if (!out.identity_phone && href.startsWith('tel:')) {
+      out.identity_phone = normalizePhone(href.slice(4));
+    }
+  }
+  return out;
+}
+
+function relationshipPass(raw = {}) {
+  const out = {};
+  for (const a of raw.anchors || []) {
+    const href = a.href || '';
+    if (!out.social_links_facebook && /facebook\.com/i.test(href)) {
+      out.social_links_facebook = cleanSocialUrl(href, 'facebook') || href;
+    }
+  }
+  return out;
+}
+
+const { computeCoverage } = require('./coverage.ts');
+
+function resolvePasses(raw = {}, allow = []) {
+  const allowSet = new Set(allow);
+  const fields = {};
+  const trace = [];
+  let unresolved = new Set(allow);
+
+  const passes = [
+    ['metadata', metadataPass],
+    ['entities', entityPass],
+    ['relationships', relationshipPass],
+  ];
+
+  for (const [stage, fn] of passes) {
+    const newFields = fn(raw, fields);
+    Object.assign(fields, newFields);
+    unresolved = new Set([...allowSet].filter((k) => fields[k] === undefined || fields[k] === null || fields[k] === ''));
+    const coverage = computeCoverage(fields, allowSet);
+    trace.push({ stage, unresolved: Array.from(unresolved), coverage });
+  }
+
+  return { fields, trace };
+}
+
 module.exports = {
   similar,
   pickBest,
@@ -317,5 +382,6 @@ module.exports = {
   cleanSocialUrl,
   resolveSocialLinks,
   resolveIdentity,
+  resolvePasses,
 };
 

--- a/test/coverage.resolve.test.js
+++ b/test/coverage.resolve.test.js
@@ -3,6 +3,64 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 
+test('metadata pass captures basic fields and notes unresolved', () => {
+  const { resolvePasses } = require('../lib/resolve');
+  const raw = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/apply-intent.raw.json'), 'utf8'));
+  const allow = [
+    'identity_owner_name',
+    'identity_website_url',
+    'identity_logo_url',
+    'identity_email',
+    'identity_phone',
+    'social_links_facebook'
+  ];
+  const { trace } = resolvePasses(raw, allow);
+  const meta = trace[0];
+  assert.equal(meta.stage, 'metadata');
+  assert.deepEqual(meta.unresolved.sort(), ['identity_email', 'identity_phone', 'social_links_facebook'].sort());
+  assert.equal(meta.coverage, 0.5);
+});
+
+test('entities pass resolves contact fields and narrows unresolved set', () => {
+  const { resolvePasses } = require('../lib/resolve');
+  const raw = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/apply-intent.raw.json'), 'utf8'));
+  const allow = [
+    'identity_owner_name',
+    'identity_website_url',
+    'identity_logo_url',
+    'identity_email',
+    'identity_phone',
+    'social_links_facebook'
+  ];
+  const { fields, trace } = resolvePasses(raw, allow);
+  const entities = trace[1];
+  assert.equal(entities.stage, 'entities');
+  assert.equal(fields.identity_email, 'info@biz.example.com');
+  assert.equal(fields.identity_phone, '+61212345678');
+  assert.deepEqual(entities.unresolved, ['social_links_facebook']);
+  assert.ok(entities.coverage > trace[0].coverage);
+});
+
+test('relationships pass completes social links and achieves full coverage', () => {
+  const { resolvePasses } = require('../lib/resolve');
+  const raw = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/apply-intent.raw.json'), 'utf8'));
+  const allow = [
+    'identity_owner_name',
+    'identity_website_url',
+    'identity_logo_url',
+    'identity_email',
+    'identity_phone',
+    'social_links_facebook'
+  ];
+  const { fields, trace } = resolvePasses(raw, allow);
+  const rel = trace[2];
+  assert.equal(rel.stage, 'relationships');
+  assert.equal(fields.social_links_facebook, 'https://facebook.com/biz');
+  assert.equal(rel.unresolved.length, 0);
+  assert.ok(rel.coverage > trace[1].coverage);
+  assert.equal(rel.coverage, 1);
+});
+
 test('applyIntent populates identity and service fields and falls back to LLM', async () => {
   const imap = require('../lib/intent_map');
   imap.loadIntentMap = () => ({


### PR DESCRIPTION
## Summary
- Orchestrate metadata, entity, and relationship passes in `lib/resolve.js`
- Track unresolved fields between passes and compute coverage metrics
- Add tests ensuring each pass resolves fields and improves coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeda55caec832abe2e5b8ed3777ac6