### PR TITLE
feat: add reference checking for fields

### DIFF
--- a/lib/completeness.js
+++ b/lib/completeness.js
@@ -1,8 +1,10 @@
 "use strict";
 const { expandKeys, categoryOf } = require('./intent_map');
+const { referenceCheck } = require('./referenceCheck');
 
 function completeness(map = {}, fields = {}) {
   const keys = expandKeys(map);
+  const reference_errors = referenceCheck(fields);
   const present_keys = keys.filter((k) => fields[k]);
   const missing = keys.filter((k) => !fields[k]);
   const totals = {
@@ -40,7 +42,8 @@ function completeness(map = {}, fields = {}) {
     present_keys,
     missing_keys_sample: missing.slice(0, 40),
     by_category,
-    high_impact_missing
+    high_impact_missing,
+    reference_errors
   };
 }
 

--- a/lib/referenceCheck.js
+++ b/lib/referenceCheck.js
@@ -1,0 +1,24 @@
+"use strict";
+
+// Simple reference lookups for validating structured fields.
+
+const countryCodes = new Set(["US", "CA", "GB"]);
+const knownIds = new Set(["ID123", "ID456"]);
+
+/**
+ * Validate field values against known reference lists.
+ * @param {Object} fields key/value pairs to validate
+ * @returns {Object} map of field names to error messages
+ */
+function referenceCheck(fields = {}) {
+  const errors = {};
+  if (fields.country_code && !countryCodes.has(fields.country_code)) {
+    errors.country_code = `Unknown country code: ${fields.country_code}`;
+  }
+  if (fields.id && !knownIds.has(fields.id)) {
+    errors.id = `Unknown id: ${fields.id}`;
+  }
+  return errors;
+}
+
+module.exports = { referenceCheck };

--- a/test/referenceCheck.test.js
+++ b/test/referenceCheck.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { referenceCheck } = require('../lib/referenceCheck');
+const { completeness } = require('../lib/completeness');
+
+// Successful lookup should return empty error object
+// Use known country code and ID
+
+test('referenceCheck accepts known references', () => {
+  const errors = referenceCheck({ country_code: 'US', id: 'ID123' });
+  assert.deepStrictEqual(errors, {});
+});
+
+// Failing lookup should report both unknown values
+
+test('referenceCheck reports unknown references', () => {
+  const errors = referenceCheck({ country_code: 'ZZ', id: 'BAD' });
+  assert.deepStrictEqual(errors, {
+    country_code: 'Unknown country code: ZZ',
+    id: 'Unknown id: BAD'
+  });
+});
+
+// Integration: completeness should include reference_errors field
+
+test('completeness exposes reference errors', () => {
+  const map = { country_code: {}, id: {} };
+  const result = completeness(map, { country_code: 'ZZ', id: 'ID123' });
+  assert.deepStrictEqual(result.reference_errors, {
+    country_code: 'Unknown country code: ZZ'
+  });
+});


### PR DESCRIPTION
## Summary
- add reference check module for country codes and IDs
- validate references during completeness evaluation
- test reference checks and completeness integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aeda544610832aa0e1d36927875d43