### PR TITLE
feat: extract deterministic address

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -367,6 +367,7 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
   add('identity_website_url', det.getDomain(raw), (v) => det.URL_RX.test(v));
   add('identity_business_name', det.getBusinessName(raw), (v) => !!String(v).trim());
   add('identity_abn', det.getABN(raw), (v) => det.ABN_RX.test(v));
+  add('identity_address', det.getAddress(raw), (v) => det.ADDRESS_RX.test(v));
   const logoKey = allowSet.has('brand_logo_url')
     ? 'brand_logo_url'
     : (allowSet.has('identity_logo_url') ? 'identity_logo_url' : null);

--- a/test/fixtures/address_heading_only.html
+++ b/test/fixtures/address_heading_only.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head><title>Address in Heading</title></head>
+  <body>
+    <h1>Contact Us</h1>
+    <h2>456 Example Street, Sydney, NSW 2000</h2>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- populate `identity_address` using deterministic extractor
- test that missing parse address is recovered by `det.getAddress`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeed82f5f8832a8e7611598c661c91