### PR TITLE
Expand deterministic scraping coverage and logging

### DIFF
--- a/lib/intent.js
+++ b/lib/intent.js
@@ -276,6 +276,38 @@ const helpers = {
         }
       }
     }
+    const detSocials = det.getSocials(raw);
+    for (const [k, v] of Object.entries(detSocials)) {
+      if (!out[k] && v.value) out[k] = v.value;
+    }
+    if (!out.identity_business_name) {
+      const v = det.getBusinessName(raw).value;
+      if (v) out.identity_business_name = v;
+    }
+    if (!out.identity_logo_url) {
+      const v = det.getLogoUrl(raw).value;
+      if (v) out.identity_logo_url = v;
+    }
+    if (!out.identity_address) {
+      const v = det.getAddress(raw).value;
+      if (v) out.identity_address = v;
+    }
+    if (!out.identity_abn) {
+      const v = det.getABN(raw).value;
+      if (v) out.identity_abn = v;
+    }
+    if (!out.identity_email) {
+      const v = det.getEmail(raw).value;
+      if (v) out.identity_email = v.toLowerCase();
+    }
+    if (!out.identity_phone) {
+      const v = det.getPhone(raw).value;
+      if (v) out.identity_phone = v;
+    }
+    if (!out.identity_website_url) {
+      const v = det.getDomain(raw).value;
+      if (v) out.identity_website_url = v;
+    }
     return out;
   },
   detResolve(key, rule, ctx) {
@@ -380,6 +412,7 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
   trace.push({ stage: 'det_summary', set: Object.keys(byKey).length, byKey, raw_counts: rawCounts });
 
   const llmClient = opts.noLLM ? { resolveField: async () => '' } : llm;
+  if (opts.noLLM) trace.push({ stage: 'llm_skipped', reason: 'no_llm_option' });
   const { fields, audit } = await runExecutor({ map, allowSet, raw, tradecard, llm: llmClient, helpers });
 
   const mvf = await resolveMVF({ raw, tradecard, allowKeys: allowSet });
@@ -430,6 +463,8 @@ exports.applyIntent = async function applyIntent(tradecard = {}, { raw = {}, ful
       }
     }
     trace.push({ stage: 'llm_merge', proposed: Object.keys(proposals).length, accepted, rejected });
+  } else {
+    trace.push({ stage: 'llm_merge', skipped: true });
   }
   const remaining = Array.from(allowSet).filter(k => !fields[k]);
   trace.push({ stage: 'unresolved', remaining });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -34,11 +34,12 @@ function resolveUrl(u, base) {
 function parseServicePanels($, base) {
   const norm = (t) => (t || '').replace(/\s+/g, ' ').trim();
   const services = [];
-  const svcSel = '.service-panel,[class*="service" i],[id*="service" i],[class*="offer" i],[class*="package" i],[class*="plan" i]';
+  const svcSel =
+    '.service-panel,[class*="service" i],[id*="service" i],[class*="offer" i],[id*="offer" i],[class*="package" i],[id*="package" i],[class*="plan" i],[id*="plan" i],[class*="solution" i],[id*="solution" i],[class*="program" i],[id*="program" i],[class*="option" i],[id*="option" i]';
   const candidates = $(svcSel).filter((_, el) => !$(el).find(svcSel).length);
   const seen = new Set();
   candidates.each((_, el) => {
-    if (services.length >= 3) return;
+    if (services.length >= 10) return;
     const key = $.html(el);
     if (seen.has(key)) return;
     seen.add(key);
@@ -539,23 +540,26 @@ async function parse(html, pageUrl) {
   const projects = parseProjects($, baseForResolve);
 
   // Owner name/title/headshot
-  const ownerKeywords = ['owner', 'founder', 'director', 'principal', 'manager'];
+  const ownerKeywords = ['owner', 'founder', 'director', 'principal', 'manager', 'ceo', 'proprietor', 'operator', 'partner', 'co-owner', 'cofounder'];
   let ownerName =
     $('.owner .name').first().text().trim() ||
     $('[data-owner-name]').first().text().trim() ||
+    $('[itemprop="founder" i], [itemprop="owner" i]').first().text().trim() ||
     null;
   let ownerTitle =
     $('.owner .title').first().text().trim() ||
     $('[data-owner-title]').first().text().trim() ||
+    $('[itemprop="jobTitle" i]').first().text().trim() ||
     null;
   let headshotUrl =
     resolveUrl($('.owner img').first().attr('src'), baseForResolve) ||
     resolveUrl($('img[alt*="headshot" i]').first().attr('src'), baseForResolve) ||
+    resolveUrl($('img[itemprop="image" i]').first().attr('src'), baseForResolve) ||
     null;
 
   if (!ownerName || !ownerTitle || !headshotUrl) {
     for (const kw of ownerKeywords) {
-      const $sec = $(`[class*='${kw}' i], [id*='${kw}' i]`).first();
+      const $sec = $(`[class*='${kw}' i], [id*='${kw}' i], [itemprop*='${kw}' i]`).first();
       if (!$sec.length) continue;
       if (!ownerName) {
         ownerName = norm(
@@ -578,6 +582,12 @@ async function parse(html, pageUrl) {
       }
       if (ownerName && ownerTitle && headshotUrl) break;
     }
+  }
+  if (!ownerTitle) {
+    ownerTitle = norm($('[itemprop="jobTitle" i]').first().text()) || ownerTitle;
+  }
+  if (!headshotUrl) {
+    headshotUrl = resolveUrl($('img[itemprop="image" i]').first().attr('src'), baseForResolve) || headshotUrl;
   }
   let identityBusinessName = null;
   let identityLogoUrl = null;
@@ -628,6 +638,12 @@ async function parse(html, pageUrl) {
     if (!isPerson && !isOrg) continue;
     const nm = ent.name || ent.legalName;
     if (isPerson && !ownerName && nm) ownerName = String(nm).trim();
+    if (isPerson && !ownerTitle && ent.jobTitle) ownerTitle = String(ent.jobTitle).trim();
+    if (isPerson && !headshotUrl && ent.image) {
+      let img = ent.image;
+      if (typeof img === 'object') img = img.url || img['@id'];
+      headshotUrl = resolveUrl(img, baseForResolve);
+    }
     if (isOrg && !identityBusinessName && nm) identityBusinessName = String(nm).trim();
     if (!identityLogoUrl && ent.logo) {
       let logo = ent.logo;


### PR DESCRIPTION
## Summary
- Broaden service panel parsing to recognise more section patterns and capture up to ten services
- Enhance owner info extraction with additional DOM patterns and JSON-LD job titles and images
- Seed more identity and social fields deterministically and log when LLM inference is skipped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af7ac78e20832aa6f5537519752b94