### PR TITLE
feat: add prompt builder with chunking and metadata

### DIFF
--- a/lib/prompt_builder.js
+++ b/lib/prompt_builder.js
@@ -1,0 +1,64 @@
+"use strict";
+
+function chunkText(text = "", maxLen = 2000) {
+  const chunks = [];
+  let idx = 0;
+  const str = String(text);
+  while (idx < str.length) {
+    chunks.push(str.slice(idx, idx + maxLen));
+    idx += maxLen;
+  }
+  return chunks;
+}
+
+function serializeFields(data, prefix = []) {
+  const lines = [];
+  if (Array.isArray(data)) {
+    data.forEach((value, index) => {
+      lines.push(...serializeFields(value, [...prefix, index]));
+    });
+  } else if (data && typeof data === "object") {
+    Object.entries(data).forEach(([key, value]) => {
+      lines.push(...serializeFields(value, [...prefix, key]));
+    });
+  } else {
+    const key = prefix.join(".");
+    lines.push(`${key}: ${data}`);
+  }
+  return lines;
+}
+
+function createContext({ input = "", intent = "", resolve = "", metadata = {}, maxChunkSize = 2000 } = {}) {
+  let formatted;
+  if (Array.isArray(input)) {
+    formatted = input.map((v) => String(v));
+  } else if (input && typeof input === "object") {
+    const lines = serializeFields(input).join("\n");
+    formatted = chunkText(lines, maxChunkSize);
+  } else {
+    formatted = chunkText(String(input), maxChunkSize);
+  }
+  return {
+    input: formatted,
+    intent,
+    resolve,
+    metadata: metadata || {}
+  };
+}
+
+function formatPrompt(ctx = {}) {
+  const sections = [];
+  (ctx.input || []).forEach((chunk, i) => {
+    const label = ctx.input.length > 1 ? `Input ${i + 1}` : "Input";
+    sections.push(`${label}:\n${chunk}`);
+  });
+  if (ctx.intent) sections.push(`Intent:\n${ctx.intent}`);
+  if (ctx.resolve) sections.push(`Resolve:\n${ctx.resolve}`);
+  if (ctx.metadata && Object.keys(ctx.metadata).length) {
+    sections.push(`Metadata:\n${JSON.stringify(ctx.metadata)}`);
+  }
+  return sections.join("\n\n");
+}
+
+module.exports = { chunkText, serializeFields, createContext, formatPrompt };
+

--- a/test/prompt_builder.test.js
+++ b/test/prompt_builder.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { chunkText, createContext, formatPrompt, serializeFields } = require('../lib/prompt_builder');
+
+test('createContext keeps intent, resolve, and metadata', () => {
+  const ctx = createContext({
+    input: 'raw-data',
+    intent: 'describe the goal',
+    resolve: 'step-by-step',
+    metadata: { id: 123 }
+  });
+  assert.deepStrictEqual(ctx.input, ['raw-data']);
+  assert.equal(ctx.intent, 'describe the goal');
+  assert.equal(ctx.resolve, 'step-by-step');
+  assert.deepStrictEqual(ctx.metadata, { id: 123 });
+});
+
+test('chunkText splits long input', () => {
+  const long = 'a'.repeat(5000);
+  const ctx = createContext({ input: long, maxChunkSize: 2000 });
+  assert.equal(ctx.input.length, 3);
+  assert.equal(ctx.input[0].length, 2000);
+  assert.equal(ctx.input[2].length, 1000);
+});
+
+test('createContext flattens object input preserving fields', () => {
+  const ctx = createContext({ input: { user: { id: 7 }, tags: ['a', 'b'] } });
+  const combined = ctx.input.join('\n');
+  assert.ok(combined.includes('user.id: 7'));
+  assert.ok(combined.includes('tags.0: a'));
+  assert.ok(combined.includes('tags.1: b'));
+});
+
+test('serializeFields outputs key paths', () => {
+  const lines = serializeFields({ a: { b: 1 }, list: [2] });
+  assert.deepStrictEqual(lines.sort(), ['a.b: 1', 'list.0: 2']);
+});
+
+test('formatPrompt builds structured sections', () => {
+  const ctx = createContext({
+    input: 'hello',
+    intent: 'greet',
+    resolve: 'return greeting',
+    metadata: { source: 'unit-test' }
+  });
+  const prompt = formatPrompt(ctx);
+  assert.ok(prompt.includes('Input:\nhello'));
+  assert.ok(prompt.includes('Intent:\ngreet'));
+  assert.ok(prompt.includes('Resolve:\nreturn greeting'));
+  assert.ok(prompt.includes('"source":"unit-test"'));
+});
+


### PR DESCRIPTION
## Summary
- add prompt_builder helper to package input, intent, resolve, and metadata
- support chunking long input and formatting structured prompt
- flatten object inputs into key-path lines for maximal data extraction
- test prompt builder for chunking, metadata, field flattening, and section formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68affc2b3e30832ab38a7961d48998e4